### PR TITLE
Make a copy of metadata map before writing to it

### DIFF
--- a/util/metautils/single_key.go
+++ b/util/metautils/single_key.go
@@ -45,9 +45,10 @@ func SetSingle(ctx context.Context, keyName string, keyValue string) context.Con
 		md = metadata.Pairs(keyName, keyValue)
 		return metadata.NewContext(ctx, md)
 	}
+	newMD := md.Copy()
 	k, v := encodeKeyValue(keyName, keyValue)
-	md[k] = []string{v}
-	return ctx // we use the same context because we modified the metadata in place.
+	newMD[k] = []string{v}
+	return metadata.NewContext(ctx, newMD)
 }
 
 func encodeKeyValue(k, v string) (string, string) {

--- a/util/metautils/single_key_test.go
+++ b/util/metautils/single_key_test.go
@@ -54,3 +54,13 @@ func TestSingleFailsReading(t *testing.T) {
 		})
 	}
 }
+
+func TestSingleImmutableMD(t *testing.T) {
+	key := "someKey"
+	value := "123456"
+	md := metadata.Pairs(key, value)
+	parent := metadata.NewContext(context.Background(), md)
+	ctx := metautils.SetSingle(parent, "otherKey", "654321")
+	newMD, _ := metadata.FromContext(ctx)
+	assert.NotEqual(t, newMD, md, "new MD must be a copy of parent MD")
+}


### PR DESCRIPTION
MD returned by `metadata.FromContext` should be immutable and writing
to it may cause races.

Fixes #21.