### PR TITLE
Make duration log configurable

### DIFF
--- a/logging/logrus/DOC.md
+++ b/logging/logrus/DOC.md
@@ -31,6 +31,12 @@ var (
 ```
 
 ```go
+var DefaultDurationToField = DurationToTimeMillisField
+```
+DefaultDurationToField is the default implementation of converting request
+duration to a log field (key and value).
+
+```go
 var (
 	// JsonPBMarshaller is the marshaller used for serializing protobuf messages.
 	JsonPbMarshaller = &jsonpb.Marshaler{}
@@ -52,6 +58,21 @@ func DefaultCodeToLevel(code codes.Code) logrus.Level
 ```
 DefaultCodeToLevel is the default implementation of gRPC return codes to log
 levels for server side.
+
+#### func  DurationToDurationField
+
+```go
+func DurationToDurationField(duration time.Duration) (key string, value interface{})
+```
+DurationToDurationField uses the duration value to log the request duration.
+
+#### func  DurationToTimeMillisField
+
+```go
+func DurationToTimeMillisField(duration time.Duration) (key string, value interface{})
+```
+DurationToTimeMillisField converts the duration to milliseconds and uses the key
+`grpc.time_ms`.
 
 #### func  Extract
 
@@ -151,6 +172,14 @@ type CodeToLevel func(code codes.Code) logrus.Level
 CodeToLevel function defines the mapping between gRPC return codes and
 interceptor log level.
 
+#### type DurationToField
+
+```go
+type DurationToField func(duration time.Duration) (key string, value interface{})
+```
+
+DurationToField function defines how to produce duration fields for logging
+
 #### type Option
 
 ```go
@@ -164,6 +193,14 @@ type Option func(*options)
 func WithCodes(f grpc_logging.ErrorToCode) Option
 ```
 WithCodes customizes the function for mapping errors to error codes.
+
+#### func  WithDurationField
+
+```go
+func WithDurationField(f DurationToField) Option
+```
+WithDurationField customizes the function for mapping request durations to log
+fields.
 
 #### func  WithLevels
 

--- a/logging/logrus/client_interceptors.go
+++ b/logging/logrus/client_interceptors.go
@@ -39,9 +39,10 @@ func StreamClientInterceptor(entry *logrus.Entry, opts ...Option) grpc.StreamCli
 func logFinalClientLine(o *options, entry *logrus.Entry, startTime time.Time, err error, msg string) {
 	code := o.codeFunc(err)
 	level := o.levelFunc(code)
+	durField, durVal := o.durationFunc(time.Now().Sub(startTime))
 	fields := logrus.Fields{
-		"grpc.code":    code.String(),
-		"grpc.time_ms": timeDiffToMilliseconds(startTime),
+		"grpc.code": code.String(),
+		durField:    durVal,
 	}
 	if err != nil {
 		fields[logrus.ErrorKey] = err

--- a/logging/logrus/server_interceptors.go
+++ b/logging/logrus/server_interceptors.go
@@ -30,9 +30,10 @@ func UnaryServerInterceptor(entry *logrus.Entry, opts ...Option) grpc.UnaryServe
 		resp, err := handler(newCtx, req)
 		code := o.codeFunc(err)
 		level := o.levelFunc(code)
+		durField, durVal := o.durationFunc(time.Now().Sub(startTime))
 		fields := logrus.Fields{
-			"grpc.code":    code.String(),
-			"grpc.time_ms": timeDiffToMilliseconds(startTime),
+			"grpc.code": code.String(),
+			durField:    durVal,
 		}
 		if err != nil {
 			fields[logrus.ErrorKey] = err
@@ -57,9 +58,10 @@ func StreamServerInterceptor(entry *logrus.Entry, opts ...Option) grpc.StreamSer
 		err := handler(srv, wrapped)
 		code := o.codeFunc(err)
 		level := o.levelFunc(code)
+		durField, durVal := o.durationFunc(time.Now().Sub(startTime))
 		fields := logrus.Fields{
-			"grpc.code":    code.String(),
-			"grpc.time_ms": timeDiffToMilliseconds(startTime),
+			"grpc.code": code.String(),
+			durField:    durVal,
 		}
 		if err != nil {
 			fields[logrus.ErrorKey] = err
@@ -100,8 +102,4 @@ func newLoggerForCall(ctx context.Context, entry *logrus.Entry, fullMethodString
 			"grpc.method":  method,
 		})
 	return toContext(ctx, callLog)
-}
-
-func timeDiffToMilliseconds(then time.Time) float32 {
-	return float32(time.Now().Sub(then).Nanoseconds() / 1000 / 1000)
 }

--- a/logging/logrus/server_interceptors_test.go
+++ b/logging/logrus/server_interceptors_test.go
@@ -140,3 +140,72 @@ func (s *logrusServerSuite) TestPingList_WithCustomTags() {
 	assert.Contains(s.T(), msgs[1], `"level": "info"`, "OK error codes must be logged on info level.")
 	assert.Contains(s.T(), msgs[1], `"grpc.time_ms":`, "interceptor log statement should contain execution time")
 }
+
+func TestLogrusServerOverrideSuite(t *testing.T) {
+	if strings.HasPrefix(runtime.Version(), "go1.7") {
+		t.Skip("Skipping due to json.RawMessage incompatibility with go1.7")
+		return
+	}
+	opts := []grpc_logrus.Option{
+		grpc_logrus.WithDurationField(grpc_logrus.DurationToDurationField),
+	}
+	b := newLogrusBaseSuite(t)
+	b.InterceptorTestSuite.ServerOpts = []grpc.ServerOption{
+		grpc_middleware.WithStreamServerChain(
+			grpc_ctxtags.StreamServerInterceptor(),
+			grpc_logrus.StreamServerInterceptor(logrus.NewEntry(b.logger), opts...)),
+		grpc_middleware.WithUnaryServerChain(
+			grpc_ctxtags.UnaryServerInterceptor(),
+			grpc_logrus.UnaryServerInterceptor(logrus.NewEntry(b.logger), opts...)),
+	}
+	suite.Run(t, &logrusServerOverrideSuite{b})
+}
+
+type logrusServerOverrideSuite struct {
+	*logrusBaseSuite
+}
+
+func (s *logrusServerOverrideSuite) TestPing_HasOverriddenDuration() {
+	_, err := s.Client.Ping(s.SimpleCtx(), goodPing)
+	assert.NoError(s.T(), err, "there must be not be an on a successful call")
+	msgs := s.getOutputJSONs()
+	assert.Len(s.T(), msgs, 2, "two log statements should be logged")
+	for _, m := range msgs {
+		s.T()
+		assert.Contains(s.T(), m, `"grpc.service": "mwitkow.testproto.TestService"`, "all lines must contain service name")
+		assert.Contains(s.T(), m, `"grpc.method": "Ping"`, "all lines must contain method name")
+	}
+	assert.Contains(s.T(), msgs[0], `"msg": "some ping"`, "handler's message must contain user message")
+	assert.NotContains(s.T(), msgs[0], "grpc.time_ms", "handler's message must not contain default duration")
+	assert.NotContains(s.T(), msgs[0], "grpc.duration", "handler's message must not contain overridden duration")
+	assert.Contains(s.T(), msgs[1], `"msg": "finished unary call"`, "interceptor message must contain string")
+	assert.Contains(s.T(), msgs[1], `"level": "info"`, "OK error codes must be logged on info level.")
+	assert.NotContains(s.T(), msgs[1], "grpc.time_ms", "interceptor message must not contain default duration")
+	assert.Contains(s.T(), msgs[1], "grpc.duration", "interceptor message must contain overridden duration")
+}
+
+func (s *logrusServerOverrideSuite) TestPingList_HasOverriddenDuration() {
+	stream, err := s.Client.PingList(s.SimpleCtx(), goodPing)
+	require.NoError(s.T(), err, "should not fail on establishing the stream")
+	for {
+		_, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		require.NoError(s.T(), err, "reading stream should not fail")
+	}
+	msgs := s.getOutputJSONs()
+	assert.Len(s.T(), msgs, 2, "two log statements should be logged")
+	for _, m := range msgs {
+		s.T()
+		assert.Contains(s.T(), m, `"grpc.service": "mwitkow.testproto.TestService"`, "all lines must contain service name")
+		assert.Contains(s.T(), m, `"grpc.method": "PingList"`, "all lines must contain method name")
+	}
+	assert.Contains(s.T(), msgs[0], `"msg": "some pinglist"`, "handler's message must contain user message")
+	assert.NotContains(s.T(), msgs[0], "grpc.time_ms", "handler's message must not contain default duration")
+	assert.NotContains(s.T(), msgs[0], "grpc.duration", "handler's message must not contain overridden duration")
+	assert.Contains(s.T(), msgs[1], `"msg": "finished streaming call"`, "interceptor message must contain string")
+	assert.Contains(s.T(), msgs[1], `"level": "info"`, "OK error codes must be logged on info level.")
+	assert.NotContains(s.T(), msgs[1], "grpc.time_ms", "interceptor message must not contain default duration")
+	assert.Contains(s.T(), msgs[1], "grpc.duration", "interceptor message must contain overridden duration")
+}

--- a/logging/zap/DOC.md
+++ b/logging/zap/DOC.md
@@ -38,6 +38,12 @@ var (
 ```
 
 ```go
+var DefaultDurationToField = DurationToTimeMillisField
+```
+DefaultDurationToField is the default implementation of converting request
+duration to a Zap field.
+
+```go
 var (
 	// JsonPBMarshaller is the marshaller used for serializing protobuf messages.
 	JsonPbMarshaller = &jsonpb.Marshaler{}
@@ -59,6 +65,22 @@ func DefaultCodeToLevel(code codes.Code) zapcore.Level
 ```
 DefaultCodeToLevel is the default implementation of gRPC return codes and
 interceptor log level for server side.
+
+#### func  DurationToDurationField
+
+```go
+func DurationToDurationField(duration time.Duration) zapcore.Field
+```
+DurationToDurationField uses a Duration field to log the request duration and
+leaves it up to Zap's encoder settings to determine how that is output.
+
+#### func  DurationToTimeMillisField
+
+```go
+func DurationToTimeMillisField(duration time.Duration) zapcore.Field
+```
+DurationToTimeMillisField converts the duration to milliseconds and uses the key
+`grpc.time_ms`.
 
 #### func  Extract
 
@@ -156,6 +178,14 @@ type CodeToLevel func(code codes.Code) zapcore.Level
 CodeToLevel function defines the mapping between gRPC return codes and
 interceptor log level.
 
+#### type DurationToField
+
+```go
+type DurationToField func(duration time.Duration) zapcore.Field
+```
+
+DurationToField function defines how to produce duration fields for logging
+
 #### type Option
 
 ```go
@@ -169,6 +199,14 @@ type Option func(*options)
 func WithCodes(f grpc_logging.ErrorToCode) Option
 ```
 WithCodes customizes the function for mapping errors to error codes.
+
+#### func  WithDurationField
+
+```go
+func WithDurationField(f DurationToField) Option
+```
+WithDurationField customizes the function for mapping request durations to Zap
+fields.
 
 #### func  WithLevels
 

--- a/logging/zap/client_interceptors.go
+++ b/logging/zap/client_interceptors.go
@@ -48,7 +48,7 @@ func logFinalClientLine(o *options, logger *zap.Logger, startTime time.Time, err
 	logger.Check(level, msg).Write(
 		zap.Error(err),
 		zap.String("grpc.code", code.String()),
-		zap.Float32("grpc.time_ms", timeDiffToMilliseconds(startTime)),
+		o.durationFunc(time.Now().Sub(startTime)),
 	)
 }
 

--- a/logging/zap/examples_test.go
+++ b/logging/zap/examples_test.go
@@ -7,11 +7,13 @@ import (
 	pb_testproto "github.com/grpc-ecosystem/go-grpc-middleware/testing/testproto"
 
 	"context"
+	"time"
 
 	"github.com/grpc-ecosystem/go-grpc-middleware"
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap"
 	"github.com/grpc-ecosystem/go-grpc-middleware/tags"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 	"google.golang.org/grpc"
 )
 
@@ -34,6 +36,28 @@ func Example_initialization(zapLogger *zap.Logger, customFunc grpc_zap.CodeToLev
 			grpc_zap.StreamServerInterceptor(zapLogger, opts...),
 		),
 	)
+	return server
+}
+
+// Initialization shows an initialization sequence with the duration field generation overridden.
+func Example_initializationWithDurationFieldOverride(zapLogger *zap.Logger) *grpc.Server {
+	opts := []grpc_zap.Option{
+		grpc_zap.WithDurationField(func(duration time.Duration) zapcore.Field {
+			return zap.Int64("grpc.time_ns", duration.Nanoseconds())
+		}),
+	}
+
+	server := grpc.NewServer(
+		grpc_middleware.WithUnaryServerChain(
+			grpc_ctxtags.UnaryServerInterceptor(),
+			grpc_zap.UnaryServerInterceptor(zapLogger, opts...),
+		),
+		grpc_middleware.WithStreamServerChain(
+			grpc_ctxtags.StreamServerInterceptor(),
+			grpc_zap.StreamServerInterceptor(zapLogger, opts...),
+		),
+	)
+
 	return server
 }
 

--- a/logging/zap/server_interceptors.go
+++ b/logging/zap/server_interceptors.go
@@ -36,7 +36,7 @@ func UnaryServerInterceptor(logger *zap.Logger, opts ...Option) grpc.UnaryServer
 		Extract(newCtx).Check(level, "finished unary call").Write(
 			zap.Error(err),
 			zap.String("grpc.code", code.String()),
-			zap.Float32("grpc.time_ms", timeDiffToMilliseconds(startTime)),
+			o.durationFunc(time.Now().Sub(startTime)),
 		)
 		return resp, err
 	}
@@ -59,7 +59,7 @@ func StreamServerInterceptor(logger *zap.Logger, opts ...Option) grpc.StreamServ
 		Extract(newCtx).Check(level, "finished streaming call").Write(
 			zap.Error(err),
 			zap.String("grpc.code", code.String()),
-			zap.Float32("grpc.time_ms", timeDiffToMilliseconds(startTime)),
+			o.durationFunc(time.Now().Sub(startTime)),
 		)
 		return err
 	}
@@ -79,8 +79,4 @@ func serverCallFields(ctx context.Context, fullMethodString string) []zapcore.Fi
 func newLoggerForCall(ctx context.Context, logger *zap.Logger, fullMethodString string) context.Context {
 	callLog := logger.With(serverCallFields(ctx, fullMethodString)...)
 	return toContext(ctx, callLog)
-}
-
-func timeDiffToMilliseconds(then time.Time) float32 {
-	return float32(time.Now().Sub(then).Nanoseconds() / 1000 / 1000)
 }

--- a/logging/zap/server_interceptors_test.go
+++ b/logging/zap/server_interceptors_test.go
@@ -144,3 +144,72 @@ func (s *zapServerSuite) TestPingList_WithCustomTags() {
 	assert.Contains(s.T(), msgs[1], `"level": "info"`, "OK error codes must be logged on info level.")
 	assert.Contains(s.T(), msgs[1], `grpc.time_ms":`, "interceptor log statement should contain execution time")
 }
+
+func TestZapLoggingOverrideSuite(t *testing.T) {
+	if strings.HasPrefix(runtime.Version(), "go1.7") {
+		t.Skip("Skipping due to json.RawMessage incompatibility with go1.7")
+		return
+	}
+	opts := []grpc_zap.Option{
+		grpc_zap.WithDurationField(grpc_zap.DurationToDurationField),
+	}
+	b := newBaseZapSuite(t)
+	b.InterceptorTestSuite.ServerOpts = []grpc.ServerOption{
+		grpc_middleware.WithStreamServerChain(
+			grpc_ctxtags.StreamServerInterceptor(),
+			grpc_zap.StreamServerInterceptor(b.log, opts...)),
+		grpc_middleware.WithUnaryServerChain(
+			grpc_ctxtags.UnaryServerInterceptor(),
+			grpc_zap.UnaryServerInterceptor(b.log, opts...)),
+	}
+	suite.Run(t, &zapServerOverrideSuite{b})
+}
+
+type zapServerOverrideSuite struct {
+	*zapBaseSuite
+}
+
+func (s *zapServerOverrideSuite) TestPing_HasOverriddenDuration() {
+	_, err := s.Client.Ping(s.SimpleCtx(), goodPing)
+	assert.NoError(s.T(), err, "there must be not be an error on a successful call")
+	msgs := s.getOutputJSONs()
+	assert.Len(s.T(), msgs, 2, "two log statements should be logged")
+	for _, m := range msgs {
+		s.T()
+		assert.Contains(s.T(), m, `grpc.service": "mwitkow.testproto.TestService"`, "all lines must contain service name")
+		assert.Contains(s.T(), m, `grpc.method": "Ping"`, "all lines must contain method name")
+	}
+	assert.Contains(s.T(), msgs[0], `"msg": "some ping"`, "handler's message must contain user message")
+	assert.NotContains(s.T(), msgs[0], "grpc.time_ms", "handler's message must not contain default duration")
+	assert.NotContains(s.T(), msgs[0], "grpc.duration", "handler's message must not contain overridden duration")
+	assert.Contains(s.T(), msgs[1], `"msg": "finished unary call"`, "interceptor message must contain string")
+	assert.Contains(s.T(), msgs[1], `"level": "info"`, "OK error codes must be logged on info level.")
+	assert.NotContains(s.T(), msgs[1], "grpc.time_ms", "interceptor message must not contain default duration")
+	assert.Contains(s.T(), msgs[1], "grpc.duration", "interceptor message must contain overridden duration")
+}
+
+func (s *zapServerOverrideSuite) TestPingList_HasOverriddenDuration() {
+	stream, err := s.Client.PingList(s.SimpleCtx(), goodPing)
+	require.NoError(s.T(), err, "should not fail on establishing the stream")
+	for {
+		_, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		require.NoError(s.T(), err, "reading stream should not fail")
+	}
+	msgs := s.getOutputJSONs()
+	assert.Len(s.T(), msgs, 2, "two log statements should be logged")
+	for _, m := range msgs {
+		s.T()
+		assert.Contains(s.T(), m, `grpc.service": "mwitkow.testproto.TestService"`, "all lines must contain service name")
+		assert.Contains(s.T(), m, `grpc.method": "PingList"`, "all lines must contain method name")
+	}
+	assert.Contains(s.T(), msgs[0], `"msg": "some pinglist"`, "handler's message must contain user message")
+	assert.NotContains(s.T(), msgs[0], "grpc.time_ms", "handler's message must not contain default duration")
+	assert.NotContains(s.T(), msgs[0], "grpc.duration", "handler's message must not contain overridden duration")
+	assert.Contains(s.T(), msgs[1], `"msg": "finished streaming call"`, "interceptor message must contain string")
+	assert.Contains(s.T(), msgs[1], `"level": "info"`, "OK error codes must be logged on info level.")
+	assert.NotContains(s.T(), msgs[1], "grpc.time_ms", "interceptor message must not contain default duration")
+	assert.Contains(s.T(), msgs[1], "grpc.duration", "interceptor message must contain overridden duration")
+}


### PR DESCRIPTION
Reworking the duration log field so that it can be overridden to use alternate keys or value calculations

Default behaviour maintains the current `grpc.time_ms` duration