### PR TITLE
Fix/jitter

### DIFF
--- a/util/backoffutils/backoff.go
+++ b/util/backoffutils/backoff.go
@@ -18,6 +18,6 @@ import (
 // This adds or substracts time from the duration within a given jitter fraction.
 // For example for 10s and jitter 0.1, it will returna  time within [9s, 11s])
 func JitterUp(duration time.Duration, jitter float64) time.Duration {
-	multiplier := jitter * (rand.Float64() - 0.5)
+	multiplier := jitter * (rand.Float64()*2 - 1)
 	return time.Duration(float64(duration) * (1 + multiplier))
 }

--- a/util/backoffutils/backoff_test.go
+++ b/util/backoffutils/backoff_test.go
@@ -11,10 +11,40 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// scale duration by a factor
+func scaleDuration(d time.Duration, factor float64) time.Duration {
+	return time.Duration(float64(d) * factor)
+}
+
 func TestJitterUp(t *testing.T) {
+
+	// arguments to jitterup
+	duration := 10 * time.Second
+	variance := 0.10
+
+	// bound to check
+	max := 11000 * time.Millisecond
+	min := 9000 * time.Millisecond
+	high := scaleDuration(max, 0.98)
+	low := scaleDuration(min, 1.02)
+
+	highCount := 0
+	lowCount := 0
+
 	for i := 0; i < 1000; i++ {
-		out := backoffutils.JitterUp(10*time.Second, 0.10)
-		assert.True(t, out <= 11*time.Second, "value must be <= 11s")
-		assert.True(t, out >= 9*time.Second, "value must be >= 9s")
+		out := backoffutils.JitterUp(duration, variance)
+		assert.True(t, out <= max, "value %s must be <= %s", out, max)
+		assert.True(t, out >= min, "value %s must be >= %s", out, min)
+
+		if out > high {
+			highCount++
+		}
+		if out < low {
+			lowCount++
+		}
 	}
+
+	assert.True(t, highCount != 0, "at least one sample should reach to >%s", high)
+	assert.True(t, lowCount != 0, "at least one sample should to <%s", low)
+
 }


### PR DESCRIPTION
The [JitterUp function](https://github.com/grpc-ecosystem/go-grpc-middleware/blob/e290027001ada7b4aaaefa959797407371765576/util/backoffutils/backoff.go#L20) documents: 

```
// JitterUp adds random jitter to the duration.
//
// This adds or substracts time from the duration within a given jitter fraction.
// For example for 10s and jitter 0.1, it will returna  time within [9s, 11s])
```

But the range is actually not reaching where it should be; it is only ranging from 9.5 to 10.5. 

This is a problem exactly for the reason we want jitter: create sufficient variance in delay. 

It is fixed in this PR. The first commit creates a failing testcase; the 2nd commit fixes the bug.  