### PR TITLE
Request/Response Payload Loggers for Logrus and Zap

### DIFF
--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/grpc-ecosystem/go-grpc-middleware/auth"
 	"github.com/grpc-ecosystem/go-grpc-middleware/testing"
 	pb_testproto "github.com/grpc-ecosystem/go-grpc-middleware/testing/testproto"
+	"github.com/grpc-ecosystem/go-grpc-middleware/util/metautils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/net/context"
@@ -23,7 +24,6 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/oauth"
 	"google.golang.org/grpc/metadata"
-	"github.com/grpc-ecosystem/go-grpc-middleware/util/metautils"
 )
 
 var (

--- a/auth/metadata_test.go
+++ b/auth/metadata_test.go
@@ -6,12 +6,12 @@ package grpc_auth
 import (
 	"testing"
 
+	"github.com/grpc-ecosystem/go-grpc-middleware/util/metautils"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
-	"github.com/grpc-ecosystem/go-grpc-middleware/util/metautils"
 )
 
 func TestAuthFromMD(t *testing.T) {

--- a/logging/DOC.md
+++ b/logging/DOC.md
@@ -45,6 +45,15 @@ See relevant packages below.
 func DefaultErrorToCode(err error) codes.Code
 ```
 
+#### type ClientPayloadLoggingDecider
+
+```go
+type ClientPayloadLoggingDecider func(ctx context.Context, fullMethodName string) bool
+```
+
+ClientPayloadLoggingDecider is a user-provided function for deciding whether to
+log the client-side request/response payloads
+
 #### type ErrorToCode
 
 ```go
@@ -53,3 +62,12 @@ type ErrorToCode func(err error) codes.Code
 
 ErrorToCode function determines the error code of an error This makes using
 custom errors with grpc middleware easier
+
+#### type ServerPayloadLoggingDecider
+
+```go
+type ServerPayloadLoggingDecider func(ctx context.Context, fullMethodName string, servingObject interface{}) bool
+```
+
+ServerPayloadLoggingDecider is a user-provided function for deciding whether to
+log the server-side request/response payloads

--- a/logging/common.go
+++ b/logging/common.go
@@ -6,6 +6,7 @@ package grpc_logging
 import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"golang.org/x/net/context"
 )
 
 // ErrorToCode function determines the error code of an error
@@ -15,3 +16,12 @@ type ErrorToCode func(err error) codes.Code
 func DefaultErrorToCode(err error) codes.Code {
 	return grpc.Code(err)
 }
+
+
+// ServerPayloadLoggingDecider is a user-provided function for deciding whether to log the server-side
+// request/response payloads
+type ServerPayloadLoggingDecider func(ctx context.Context, fullMethodName string, servingObject interface{}) bool
+
+// ClientPayloadLoggingDecider is a user-provided function for deciding whether to log the client-side
+// request/response payloads
+type ClientPayloadLoggingDecider func(ctx context.Context, fullMethodName string) bool

--- a/logging/common.go
+++ b/logging/common.go
@@ -4,9 +4,9 @@
 package grpc_logging
 
 import (
+	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
-	"golang.org/x/net/context"
 )
 
 // ErrorToCode function determines the error code of an error
@@ -16,7 +16,6 @@ type ErrorToCode func(err error) codes.Code
 func DefaultErrorToCode(err error) codes.Code {
 	return grpc.Code(err)
 }
-
 
 // ServerPayloadLoggingDecider is a user-provided function for deciding whether to log the server-side
 // request/response payloads

--- a/logging/logrus/DOC.md
+++ b/logging/logrus/DOC.md
@@ -30,6 +30,13 @@ var (
 )
 ```
 
+```go
+var (
+	// JsonPBMarshaller is the marshaller used for serializing protobuf messages.
+	JsonPbMarshaller = &jsonpb.Marshaler{}
+)
+```
+
 #### func  DefaultClientCodeToLevel
 
 ```go
@@ -55,6 +62,44 @@ Extract takes the call-scoped logrus.Entry from grpc_logrus middleware.
 
 If the grpc_logrus middleware wasn't used, a no-op `logrus.Entry` is returned.
 This makes it safe to use regardless.
+
+#### func  PayloadStreamClientInterceptor
+
+```go
+func PayloadStreamClientInterceptor(entry *logrus.Entry, decider grpc_logging.ClientPayloadLoggingDecider) grpc.StreamClientInterceptor
+```
+PayloadStreamServerInterceptor returns a new streaming client interceptor that
+logs the paylods of requests and responses.
+
+#### func  PayloadStreamServerInterceptor
+
+```go
+func PayloadStreamServerInterceptor(entry *logrus.Entry, decider grpc_logging.ServerPayloadLoggingDecider) grpc.StreamServerInterceptor
+```
+PayloadUnaryServerInterceptor returns a new server server interceptors that logs
+the payloads of requests.
+
+This *only* works when placed *after* the `grpc_logrus.StreamServerInterceptor`.
+However, the logging can be done to a separate instance of the logger.
+
+#### func  PayloadUnaryClientInterceptor
+
+```go
+func PayloadUnaryClientInterceptor(entry *logrus.Entry, decider grpc_logging.ClientPayloadLoggingDecider) grpc.UnaryClientInterceptor
+```
+PayloadUnaryClientInterceptor returns a new unary client interceptor that logs
+the paylods of requests and responses.
+
+#### func  PayloadUnaryServerInterceptor
+
+```go
+func PayloadUnaryServerInterceptor(entry *logrus.Entry, decider grpc_logging.ServerPayloadLoggingDecider) grpc.UnaryServerInterceptor
+```
+PayloadUnaryServerInterceptor returns a new unary server interceptors that logs
+the payloads of requests.
+
+This *only* works when placed *after* the `grpc_logrus.UnaryServerInterceptor`.
+However, the logging can be done to a separate instance of the logger.
 
 #### func  ReplaceGrpcLogger
 
@@ -94,7 +139,7 @@ logs the execution of external gRPC calls.
 ```go
 func UnaryServerInterceptor(entry *logrus.Entry, opts ...Option) grpc.UnaryServerInterceptor
 ```
-UnaryServerInterceptor returns a new unary server interceptors that adds
+PayloadUnaryServerInterceptor returns a new unary server interceptors that adds
 logrus.Entry to the context.
 
 #### type CodeToLevel

--- a/logging/logrus/options.go
+++ b/logging/logrus/options.go
@@ -21,29 +21,24 @@ type options struct {
 	codeFunc  grpc_logging.ErrorToCode
 }
 
-func evaluateOptions(opts []Option) *options {
+func evaluateServerOpt(opts []Option) *options {
 	optCopy := &options{}
 	*optCopy = *defaultOptions
+	optCopy.levelFunc = DefaultCodeToLevel
 	for _, o := range opts {
 		o(optCopy)
 	}
 	return optCopy
 }
 
-func evaluateServerOpt(opts []Option) *options {
-	o := evaluateOptions(opts)
-	if o.codeFunc == nil {
-		o.levelFunc = DefaultCodeToLevel
-	}
-	return o
-}
-
 func evaluateClientOpt(opts []Option) *options {
-	o := evaluateOptions(opts)
-	if o.codeFunc == nil {
-		o.levelFunc = DefaultCodeToLevel
+	optCopy := &options{}
+	*optCopy = *defaultOptions
+	optCopy.levelFunc = DefaultClientCodeToLevel
+	for _, o := range opts {
+		o(optCopy)
 	}
-	return o
+	return optCopy
 }
 
 type Option func(*options)

--- a/logging/logrus/payload_interceptors.go
+++ b/logging/logrus/payload_interceptors.go
@@ -1,0 +1,146 @@
+// Copyright 2017 Michal Witkowski. All Rights Reserved.
+// See LICENSE for licensing terms.
+
+package grpc_logrus
+
+import (
+	"bytes"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/golang/protobuf/jsonpb"
+	"github.com/golang/protobuf/proto"
+	"github.com/grpc-ecosystem/go-grpc-middleware/logging"
+	"golang.org/x/net/context"
+	"google.golang.org/grpc"
+	"fmt"
+)
+
+var (
+	// JsonPBMarshaller is the marshaller used for serializing protobuf messages.
+	JsonPbMarshaller = &jsonpb.Marshaler{}
+)
+
+// PayloadUnaryServerInterceptor returns a new unary server interceptors that logs the payloads of requests.
+//
+// This *only* works when placed *after* the `grpc_logrus.UnaryServerInterceptor`. However, the logging can be done to a
+// separate instance of the logger.
+func PayloadUnaryServerInterceptor(entry *logrus.Entry, decider grpc_logging.ServerPayloadLoggingDecider) grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+		if !decider(ctx, info.FullMethod, info.Server) {
+			return handler(ctx, req)
+		}
+		// Use the provided logrus.Entry for logging but use the fields from context.
+		logEntry := entry.WithFields(Extract(ctx).Data)
+		logProtoMessageAsJson(logEntry, req, "grpc.request.content", "server request payload logged as grpc.request.content field")
+		resp, err := handler(ctx, req)
+		if err == nil {
+			logProtoMessageAsJson(logEntry, req, "grpc.response.content", "server response payload logged as grpc.request.content field")
+		}
+		return resp, err
+	}
+}
+
+// PayloadUnaryServerInterceptor returns a new server server interceptors that logs the payloads of requests.
+//
+// This *only* works when placed *after* the `grpc_logrus.StreamServerInterceptor`. However, the logging can be done to a
+// separate instance of the logger.
+func PayloadStreamServerInterceptor(entry *logrus.Entry, decider grpc_logging.ServerPayloadLoggingDecider) grpc.StreamServerInterceptor {
+	return func(srv interface{}, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		if !decider(stream.Context(), info.FullMethod, srv) {
+			return handler(srv, stream)
+		}
+		// Use the provided logrus.Entry for logging but use the fields from context.
+		logEntry := entry.WithFields(Extract(stream.Context()).Data)
+		newStream := &loggingServerStream{ServerStream: stream, entry: logEntry}
+		return handler(srv, newStream)
+	}
+}
+
+// PayloadUnaryClientInterceptor returns a new unary client interceptor that logs the paylods of requests and responses.
+func PayloadUnaryClientInterceptor(entry *logrus.Entry, decider grpc_logging.ClientPayloadLoggingDecider) grpc.UnaryClientInterceptor {
+	return func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+		if !decider(ctx, method) {
+			return invoker(ctx, method, req, reply, cc, opts...)
+		}
+		logEntry := entry.WithFields(newClientLoggerFields(ctx, method))
+		logProtoMessageAsJson(logEntry, req, "grpc.request.content", "client request payload logged as grpc.request.content")
+		err := invoker(ctx, method, req, reply, cc, opts...)
+		if err == nil {
+			logProtoMessageAsJson(logEntry, reply, "grpc.response.content", "client response payload logged as grpc.response.content")
+		}
+		return err
+	}
+}
+
+// PayloadStreamServerInterceptor returns a new streaming client interceptor that logs the paylods of requests and responses.
+func PayloadStreamClientInterceptor(entry *logrus.Entry, decider grpc_logging.ClientPayloadLoggingDecider) grpc.StreamClientInterceptor {
+	return func(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string, streamer grpc.Streamer, opts ...grpc.CallOption) (grpc.ClientStream, error) {
+		if !decider(ctx, method) {
+			return streamer(ctx, desc, cc, method, opts...)
+		}
+		logEntry := entry.WithFields(newClientLoggerFields(ctx, method))
+		clientStream, err := streamer(ctx, desc, cc, method, opts...)
+		newStream := &loggingClientStream{ClientStream: clientStream, entry: logEntry}
+		return newStream, err
+	}
+}
+
+type loggingClientStream struct {
+	grpc.ClientStream
+	entry *logrus.Entry
+}
+
+func (l *loggingClientStream) SendMsg(m interface{}) error {
+	err := l.ClientStream.SendMsg(m)
+	if err == nil {
+		logProtoMessageAsJson(l.entry, m, "grpc.request.content", "server request payload logged as grpc.request.content field")
+	}
+	return err
+}
+
+func (l *loggingClientStream) RecvMsg(m interface{}) error {
+	err := l.ClientStream.RecvMsg(m)
+	if err == nil {
+		logProtoMessageAsJson(l.entry, m, "grpc.response.content", "server response payload logged as grpc.response.content field")
+	}
+	return err
+}
+
+type loggingServerStream struct {
+	grpc.ServerStream
+	entry *logrus.Entry
+}
+
+func (l *loggingServerStream) SendMsg(m interface{}) error {
+	err := l.ServerStream.SendMsg(m)
+	if err == nil {
+		logProtoMessageAsJson(l.entry, m, "grpc.response.content", "server response payload logged as grpc.response.content field")
+	}
+	return err
+}
+
+func (l *loggingServerStream) RecvMsg(m interface{}) error {
+	err := l.ServerStream.RecvMsg(m)
+	if err == nil {
+		logProtoMessageAsJson(l.entry, m, "grpc.request.content", "server request payload logged as grpc.request.content field")
+	}
+	return err
+}
+
+func logProtoMessageAsJson(entry *logrus.Entry, pbMsg interface{}, key string, msg string) {
+	if p, ok := pbMsg.(proto.Message); ok {
+		entry.WithField(key, &jsonpbMarshalleble{p}).Info(msg)
+	}
+}
+
+type jsonpbMarshalleble struct {
+	proto.Message
+}
+
+func (j *jsonpbMarshalleble) MarshalJSON() ([]byte, error) {
+	b := &bytes.Buffer{}
+	if err := JsonPbMarshaller.Marshal(b, j); err != nil {
+		return nil, fmt.Errorf("jsonpb serializer failed: %v", err)
+	}
+	return b.Bytes(), nil
+}

--- a/logging/logrus/payload_interceptors_test.go
+++ b/logging/logrus/payload_interceptors_test.go
@@ -1,0 +1,137 @@
+// Copyright 2017 Michal Witkowski. All Rights Reserved.
+// See LICENSE for licensing terms.
+
+package grpc_logrus_test
+
+import (
+	"runtime"
+	"testing"
+
+	"io/ioutil"
+	"strings"
+
+	"github.com/stretchr/testify/suite"
+	"google.golang.org/grpc"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/grpc-ecosystem/go-grpc-middleware"
+	"github.com/grpc-ecosystem/go-grpc-middleware/logging/logrus"
+	"github.com/grpc-ecosystem/go-grpc-middleware/tags"
+	pb_testproto "github.com/grpc-ecosystem/go-grpc-middleware/testing/testproto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/net/context"
+	"io"
+)
+
+var (
+	nullLogger = &logrus.Logger{
+		Out:       ioutil.Discard,
+		Formatter: new(logrus.TextFormatter),
+		Hooks:     make(logrus.LevelHooks),
+		Level:     logrus.PanicLevel,
+	}
+)
+
+func TestLogrusPayloadSuite(t *testing.T) {
+	if strings.HasPrefix(runtime.Version(), "go1.7") {
+		t.Skipf("Skipping due to json.RawMessage incompatibility with go1.7")
+		return
+	}
+	opts := []grpc_logrus.Option{
+		grpc_logrus.WithLevels(customCodeToLevel),
+	}
+	alwaysLoggingDeciderServer := func(ctx context.Context, fullMethodName string, servingObject interface{}) bool { return true }
+	alwaysLoggingDeciderClient := func(ctx context.Context, fullMethodName string) bool { return true }
+
+	b := newLogrusBaseSuite(t)
+	b.InterceptorTestSuite.ClientOpts = []grpc.DialOption{
+		grpc.WithUnaryInterceptor(grpc_logrus.PayloadUnaryClientInterceptor(logrus.NewEntry(b.logger), alwaysLoggingDeciderClient)),
+		grpc.WithStreamInterceptor(grpc_logrus.PayloadStreamClientInterceptor(logrus.NewEntry(b.logger), alwaysLoggingDeciderClient)),
+	}
+	b.InterceptorTestSuite.ServerOpts = []grpc.ServerOption{
+		grpc_middleware.WithStreamServerChain(
+			grpc_ctxtags.StreamServerInterceptor(grpc_ctxtags.WithFieldExtractor(grpc_ctxtags.CodeGenRequestFieldExtractor)),
+			grpc_logrus.StreamServerInterceptor(logrus.NewEntry(nullLogger), opts...),
+			grpc_logrus.PayloadStreamServerInterceptor(logrus.NewEntry(b.logger), alwaysLoggingDeciderServer)),
+		grpc_middleware.WithUnaryServerChain(
+			grpc_ctxtags.UnaryServerInterceptor(grpc_ctxtags.WithFieldExtractor(grpc_ctxtags.CodeGenRequestFieldExtractor)),
+			grpc_logrus.UnaryServerInterceptor(logrus.NewEntry(nullLogger), opts...),
+			grpc_logrus.PayloadUnaryServerInterceptor(logrus.NewEntry(b.logger), alwaysLoggingDeciderServer)),
+	}
+	suite.Run(t, &logrusPayloadSuite{b})
+}
+
+type logrusPayloadSuite struct {
+	*logrusBaseSuite
+}
+
+func (s *logrusPayloadSuite) getServerAndClientMessages(expectedServer int, expectedClient int) (serverMsgs []string, clientMsgs []string) {
+	msgs := s.getOutputJSONs()
+	for _, m := range msgs {
+		if strings.Contains(m, `"span.kind": "server"`) {
+			serverMsgs = append(serverMsgs, m)
+		} else if strings.Contains(m, `"span.kind": "client"`) {
+			clientMsgs = append(clientMsgs, m)
+		}
+	}
+	require.Len(s.T(), serverMsgs, expectedServer, "must match expected number of server log messages")
+	require.Len(s.T(), clientMsgs, expectedClient, "must match expected number of client log messages")
+	return serverMsgs, clientMsgs
+}
+
+func (s *logrusPayloadSuite) TestPing_LogsBothRequestAndResponse() {
+	_, err := s.Client.Ping(s.SimpleCtx(), goodPing)
+	assert.NoError(s.T(), err, "there must be not be an on a successful call")
+	serverMsgs, clientMsgs := s.getServerAndClientMessages(2, 2)
+	for _, m := range append(serverMsgs, clientMsgs...) {
+		assert.Contains(s.T(), m, `"grpc.service": "mwitkow.testproto.TestService"`, "all lines must contain service name")
+		assert.Contains(s.T(), m, `"grpc.method": "Ping"`, "all lines must contain method name")
+		assert.Contains(s.T(), m, `"level": "info"`, "all payloads must be logged on info level")
+	}
+	serverReq, serverResp := serverMsgs[0], serverMsgs[1]
+	clientReq, clientResp := clientMsgs[0], clientMsgs[1]
+	assert.Contains(s.T(), clientReq, `"grpc.request.content": {`, "request payload must be logged in a structured way")
+	assert.Contains(s.T(), serverReq, `"grpc.request.content": {`, "request payload must be logged in a structured way")
+	assert.Contains(s.T(), clientResp, `"grpc.response.content": {`, "response payload must be logged in a structured way")
+	assert.Contains(s.T(), serverResp, `"grpc.response.content": {`, "response payload must be logged in a structured way")
+}
+
+func (s *logrusPayloadSuite) TestPingError_LogsOnlyRequestsOnError() {
+	_, err := s.Client.PingError(s.SimpleCtx(), &pb_testproto.PingRequest{Value: "something", ErrorCodeReturned: uint32(4)})
+	require.Error(s.T(), err, "there must be not be an on a successful call")
+	serverMsgs, clientMsgs := s.getServerAndClientMessages(1, 1)
+	for _, m := range append(serverMsgs, clientMsgs...) {
+		assert.Contains(s.T(), m, `"grpc.service": "mwitkow.testproto.TestService"`, "all lines must contain service name")
+		assert.Contains(s.T(), m, `"grpc.method": "PingError"`, "all lines must contain method name")
+		assert.Contains(s.T(), m, `"level": "info"`, "all payloads must be logged on info level")
+	}
+	assert.Contains(s.T(), clientMsgs[0], `"grpc.request.content": {`, "request payload must be logged in a structured way")
+	assert.Contains(s.T(), serverMsgs[0], `"grpc.request.content": {`, "request payload must be logged in a structured way")
+}
+
+
+func (s *logrusPayloadSuite) TestPingStream_LogsAllRequestsAndResponses() {
+	messagesExpected := 20
+	stream, err := s.Client.PingStream(s.SimpleCtx())
+	require.NoError(s.T(), err, "no error on stream creation")
+	for i := 0; i < messagesExpected; i++ {
+		require.NoError(s.T(), stream.Send(goodPing), "sending must succeed")
+	}
+	require.NoError(s.T(), stream.CloseSend(), "no error on send stream")
+	for {
+		pong := &pb_testproto.PingResponse{}
+		err := stream.RecvMsg(pong)
+		if err  == io.EOF {
+			break
+		}
+		require.NoError(s.T(), err, "no error on receive")
+	}
+	serverMsgs, clientMsgs := s.getServerAndClientMessages(2*messagesExpected, 2*messagesExpected)
+	for _, m := range append(serverMsgs, clientMsgs...) {
+		assert.Contains(s.T(), m, `"grpc.service": "mwitkow.testproto.TestService"`, "all lines must contain service name")
+		assert.Contains(s.T(), m, `"grpc.method": "PingStream"`, "all lines must contain method name")
+		assert.Contains(s.T(), m, `"level": "info"`, "all payloads must be logged on info level")
+		assert.Contains(s.T(), m, `.content": {`, "all messages must contain payloads")
+	}
+}

--- a/logging/logrus/server_interceptors.go
+++ b/logging/logrus/server_interceptors.go
@@ -26,7 +26,6 @@ func UnaryServerInterceptor(entry *logrus.Entry, opts ...Option) grpc.UnaryServe
 	o := evaluateServerOpt(opts)
 	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
 		newCtx := newLoggerForCall(ctx, entry, info.FullMethod)
-
 		startTime := time.Now()
 		resp, err := handler(newCtx, req)
 		code := o.codeFunc(err)

--- a/logging/logrus/server_interceptors.go
+++ b/logging/logrus/server_interceptors.go
@@ -21,7 +21,7 @@ var (
 	KindField = "span.kind"
 )
 
-// UnaryServerInterceptor returns a new unary server interceptors that adds logrus.Entry to the context.
+// PayloadUnaryServerInterceptor returns a new unary server interceptors that adds logrus.Entry to the context.
 func UnaryServerInterceptor(entry *logrus.Entry, opts ...Option) grpc.UnaryServerInterceptor {
 	o := evaluateServerOpt(opts)
 	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {

--- a/logging/zap/DOC.md
+++ b/logging/zap/DOC.md
@@ -37,6 +37,13 @@ var (
 )
 ```
 
+```go
+var (
+	// JsonPBMarshaller is the marshaller used for serializing protobuf messages.
+	JsonPbMarshaller = &jsonpb.Marshaler{}
+)
+```
+
 #### func  DefaultClientCodeToLevel
 
 ```go
@@ -61,6 +68,44 @@ func Extract(ctx context.Context) *zap.Logger
 Extract takes the call-scoped Logger from grpc_zap middleware.
 
 It always returns a Logger that has all the grpc_ctxtags updated.
+
+#### func  PayloadStreamClientInterceptor
+
+```go
+func PayloadStreamClientInterceptor(logger *zap.Logger, decider grpc_logging.ClientPayloadLoggingDecider) grpc.StreamClientInterceptor
+```
+PayloadStreamServerInterceptor returns a new streaming client interceptor that
+logs the paylods of requests and responses.
+
+#### func  PayloadStreamServerInterceptor
+
+```go
+func PayloadStreamServerInterceptor(logger *zap.Logger, decider grpc_logging.ServerPayloadLoggingDecider) grpc.StreamServerInterceptor
+```
+PayloadUnaryServerInterceptor returns a new server server interceptors that logs
+the payloads of requests.
+
+This *only* works when placed *after* the `grpc_logrus.StreamServerInterceptor`.
+However, the logging can be done to a separate instance of the logger.
+
+#### func  PayloadUnaryClientInterceptor
+
+```go
+func PayloadUnaryClientInterceptor(logger *zap.Logger, decider grpc_logging.ClientPayloadLoggingDecider) grpc.UnaryClientInterceptor
+```
+PayloadUnaryClientInterceptor returns a new unary client interceptor that logs
+the paylods of requests and responses.
+
+#### func  PayloadUnaryServerInterceptor
+
+```go
+func PayloadUnaryServerInterceptor(logger *zap.Logger, decider grpc_logging.ServerPayloadLoggingDecider) grpc.UnaryServerInterceptor
+```
+PayloadUnaryServerInterceptor returns a new unary server interceptors that logs
+the payloads of requests.
+
+This *only* works when placed *after* the `grpc_logrus.UnaryServerInterceptor`.
+However, the logging can be done to a separate instance of the logger.
 
 #### func  ReplaceGrpcLogger
 

--- a/logging/zap/context.go
+++ b/logging/zap/context.go
@@ -26,12 +26,16 @@ func Extract(ctx context.Context) *zap.Logger {
 		return nullLogger
 	}
 	// Add grpc_ctxtags tags metadata until now.
+	return l.With(tagsFieldsToZapFields(ctx)...)
+}
+
+func tagsFieldsToZapFields(ctx context.Context) []zapcore.Field {
 	fields := []zapcore.Field{}
 	tags := grpc_ctxtags.Extract(ctx)
 	for k, v := range tags.Values() {
 		fields = append(fields, zap.Any(k, v))
 	}
-	return l.With(fields...)
+	return fields
 }
 
 func toContext(ctx context.Context, logger *zap.Logger) context.Context {

--- a/logging/zap/options.go
+++ b/logging/zap/options.go
@@ -22,29 +22,24 @@ type options struct {
 	codeFunc  grpc_logging.ErrorToCode
 }
 
-func evaluateOptions(opts []Option) *options {
+func evaluateServerOpt(opts []Option) *options {
 	optCopy := &options{}
 	*optCopy = *defaultOptions
+	optCopy.levelFunc = DefaultCodeToLevel
 	for _, o := range opts {
 		o(optCopy)
 	}
 	return optCopy
 }
 
-func evaluateServerOpt(opts []Option) *options {
-	o := evaluateOptions(opts)
-	if o.codeFunc == nil {
-		o.levelFunc = DefaultCodeToLevel
-	}
-	return o
-}
-
 func evaluateClientOpt(opts []Option) *options {
-	o := evaluateOptions(opts)
-	if o.codeFunc == nil {
-		o.levelFunc = DefaultCodeToLevel
+	optCopy := &options{}
+	*optCopy = *defaultOptions
+	optCopy.levelFunc = DefaultClientCodeToLevel
+	for _, o := range opts {
+		o(optCopy)
 	}
-	return o
+	return optCopy
 }
 
 type Option func(*options)

--- a/util/metautils/DOC.md
+++ b/util/metautils/DOC.md
@@ -5,13 +5,6 @@
 
 ## Usage
 
-#### func  Copy
-
-```go
-func Copy(parent metadata.MD) metadata.MD
-```
-Copy creates a shallow copy of the metadata.
-
 #### func  GetSingle
 
 ```go
@@ -21,6 +14,7 @@ GetSingle extracts a single-value metadata key from Context. First return is the
 value of the key, followed by a bool indicator. The bool indicator being false
 means the string should be discarded. It can be false if the context has no
 metadata at all, the key in metadata doesn't exist or there are multiple values.
+Deprecated, use NiceMD.Get.
 
 #### func  SetSingle
 
@@ -29,4 +23,100 @@ func SetSingle(ctx context.Context, keyName string, keyValue string) context.Con
 ```
 SetSingle sets or overrides a metadata key to be single value in the Context. It
 returns a new context.Context object that contains a *copy* of the metadata
-inside the given context.
+inside the given context. Deprecated, use NiceMD.Set.
+
+#### type NiceMD
+
+```go
+type NiceMD metadata.MD
+```
+
+NiceMD is a convenience wrapper definiting extra functions on the metadata.
+
+#### func  ExtractIncoming
+
+```go
+func ExtractIncoming(ctx context.Context) NiceMD
+```
+ExtractIncoming extracts an inbound metadata from the server-side context.
+
+This function always returns a NiceMD wrapper of the metadata.MD, in case the
+context doesn't have metadata it returns a new empty NiceMD.
+
+#### func  ExtractOutgoing
+
+```go
+func ExtractOutgoing(ctx context.Context) NiceMD
+```
+ExtractOutgoing extracts an outbound metadata from the client-side context.
+
+This function always returns a NiceMD wrapper of the metadata.MD, in case the
+context doesn't have metadata it returns a new empty NiceMD.
+
+#### func (NiceMD) Add
+
+```go
+func (m NiceMD) Add(key string, value string) NiceMD
+```
+Add retrieves a single value from the metadata.
+
+It works analogously to http.Header.Add, as it appends to any existing values
+associated with key.
+
+The function is binary-key safe.
+
+#### func (NiceMD) Clone
+
+```go
+func (m NiceMD) Clone(copiedKeys ...string) NiceMD
+```
+Clone performs a *deep* copy of the metadata.MD.
+
+You can specify the lower-case copiedKeys to only copy certain whitelisted keys.
+If no keys are explicitly whitelisted all keys get copied.
+
+#### func (NiceMD) Del
+
+```go
+func (m NiceMD) Del(key string) NiceMD
+```
+
+#### func (NiceMD) Get
+
+```go
+func (m NiceMD) Get(key string) string
+```
+Get retrieves a single value from the metadata.
+
+It works analogously to http.Header.Get, returning the first value if there are
+many set. If the value is not set, an empty string is returned.
+
+The function is binary-key safe.
+
+#### func (NiceMD) Set
+
+```go
+func (m NiceMD) Set(key string, value string) NiceMD
+```
+Set sets the given value in a metadata.
+
+It works analogously to http.Header.Set, overwriting all previous metadata
+values.
+
+The function is binary-key safe.
+
+#### func (NiceMD) ToIncoming
+
+```go
+func (m NiceMD) ToIncoming(ctx context.Context) context.Context
+```
+ToIncoming sets the given NiceMD as a server-side context for dispatching.
+
+This is mostly useful in ServerInterceptors..
+
+#### func (NiceMD) ToOutgoing
+
+```go
+func (m NiceMD) ToOutgoing(ctx context.Context) context.Context
+```
+ToOutgoing sets the given NiceMD as a client-side context for dispatching.

--- a/util/metautils/nicemd_test.go
+++ b/util/metautils/nicemd_test.go
@@ -5,11 +5,13 @@ package metautils_test
 
 import (
 	"testing"
-	"google.golang.org/grpc/metadata"
+
 	"github.com/grpc-ecosystem/go-grpc-middleware/util/metautils"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/net/context"
+	"google.golang.org/grpc/metadata"
 )
+
 var (
 	testPairs = []string{"singlekey", "uno", "multikey", "one", "multikey", "two", "multikey", "three"}
 	parentCtx = context.WithValue(context.TODO(), "parentKey", "parentValue")
@@ -47,7 +49,6 @@ func TestNiceMD_Set(t *testing.T) {
 	assert.EqualValues(t, []string{"one"}, nmd["multikey"], "set should override existing multi keys")
 	assert.EqualValues(t, []string{"another"}, nmd["newkey"], "set should override new keys")
 }
-
 
 func TestNiceMD_Clone(t *testing.T) {
 	nmd := metautils.NiceMD(metadata.Pairs(testPairs...))

--- a/util/metautils/single_key_test.go
+++ b/util/metautils/single_key_test.go
@@ -9,8 +9,6 @@ import (
 	"google.golang.org/grpc/metadata"
 )
 
-
-
 func TestSingleFailsReading(t *testing.T) {
 	key := "someKey"
 	for _, tcase := range []struct {


### PR DESCRIPTION
This adds RPC content logging (proto messages as JSONpb) interceptors. These interceptors can be directed at a different logger than the standard one (e.g. logging to a separate file). A user-provided function decides whether to log a given client-side or server side request.
