### PR TITLE
The repo is moved *to* the new location, not from it.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 [gRPC Go](https://github.com/grpc/grpc-go) Middleware: interceptors, helpers, utilities.
 
-**Important** The repo recently moved from `github.com/grpc-ecosystem/go-grpc-middleware`, please update your import paths.
+**Important** The repo recently moved to `github.com/grpc-ecosystem/go-grpc-middleware`, please update your import paths.
 
 ## Middleware
 


### PR DESCRIPTION
About the README.md warning: I am confused. 

https://github.com/grpc-ecosystem/go-grpc-middleware is the new location, right? 

Should it not be "moved to" then? 