### PR TITLE
Add example generation to docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 [gRPC Go](https://github.com/grpc/grpc-go) Middleware: interceptors, helpers, utilities.
 
-**Important** The repo recently moved from `github.com/grpc-ecosystem/go-grpc-middleware`, please update your import paths.
+**Important** The repo recently moved to `github.com/grpc-ecosystem/go-grpc-middleware`, please update your import paths.
 
 ## Middleware
 
@@ -24,7 +24,7 @@ These are generic building blocks that make it easy to build multiple microservi
 The purpose of this repository is to act as a go-to point for such reusable functionality. It contains
 some of them itself, but also will link to useful external repos.
 
-`grpc_middleware` itself provides support for chaining interceptors. Se [Documentation](DOC.md), but here's an example:
+`grpc_middleware` itself provides support for chaining interceptors. See [Documentation](DOC.md), but here's an example:
 
 ```go
 import "github.com/grpc-ecosystem/go-grpc-middleware"

--- a/auth/DOC.md
+++ b/auth/DOC.md
@@ -21,6 +21,42 @@ It also allows for per-service implementation overrides of `AuthFunc`. See `Serv
 
 Please see examples for simple examples of use.
 
+#### Example:
+
+<details>
+<summary>Click to expand code.</summary>
+
+```go
+token, err := grpc_auth.AuthFromMD(ctx, "bearer")
+	if err != nil {
+	    return nil, err
+	}
+	tokenInfo, err := parseToken(token)
+	if err != nil {
+	    return nil, grpc.Errorf(codes.Unauthenticated, "invalid auth token: %v", err)
+	}
+	grpc_ctxtags.Extract(ctx).Set("auth.sub", userClaimFromToken(tokenInfo))
+	newCtx := context.WithValue(ctx, "tokenInfo", tokenInfo)
+	return newCtx, nil
+```
+
+</details>
+
+#### Example:
+
+<details>
+<summary>Click to expand code.</summary>
+
+```go
+server := grpc.NewServer(
+	    grpc.StreamInterceptor(grpc_auth.StreamServerInterceptor(Example_authfunc)),
+	    grpc.UnaryInterceptor(grpc_auth.UnaryServerInterceptor(Example_authfunc)),
+	)
+	return server
+```
+
+</details>
+
 ## <a name="pkg-imports">Imported Packages</a>
 
 - [github.com/grpc-ecosystem/go-grpc-middleware](./..)

--- a/fixup.sh
+++ b/fixup.sh
@@ -17,7 +17,7 @@ function generate_markdown {
         package=${realdir##${GOPATH}/src/}
         echo "$package"
         cd ${dir}
-        ${GOBIN}/godoc2ghmd -file DOC.md ${package}
+        ${GOBIN}/godoc2ghmd -ex -file DOC.md ${package}
         ln -s DOC.md README.md 2> /dev/null # can fail
         cd ${oldpwd}
     done;

--- a/logging/logrus/DOC.md
+++ b/logging/logrus/DOC.md
@@ -15,6 +15,11 @@ It accepts a user-configured `logrus.Entry` that will be used for logging comple
 You can use `Extract` to log into a request-scoped `logrus.Entry` instance in your handler code. The fields set on the
 logger correspond to the grpc_ctxtags.Tags attached to the context.
 
+This package also implements request and response *payload* logging, both for server-side and client-side. These will be
+logged as structured `jsonbp` fields for every message received/sent (both unary and streaming). For that please use
+`Payload*Interceptor` functions for that. Please note that the user-provided function that determines whetether to log
+the full request/response payload needs to be written with care, this can significantly slow down gRPC.
+
 Logrus can also be made as a backend for gRPC library internals. For that use `ReplaceGrpcLogger`.
 
 Please see examples and tests for examples of use.

--- a/logging/logrus/DOC.md
+++ b/logging/logrus/DOC.md
@@ -19,6 +19,83 @@ Logrus can also be made as a backend for gRPC library internals. For that use `R
 
 Please see examples and tests for examples of use.
 
+#### Example:
+
+<details>
+<summary>Click to expand code.</summary>
+
+```go
+x := func(ctx context.Context, ping *pb_testproto.PingRequest) (*pb_testproto.PingResponse, error) {
+	    // Add fields the ctxtags of the request which will be added to all extracted loggers.
+	    grpc_ctxtags.Extract(ctx).Set("custom_tags.string", "something").Set("custom_tags.int", 1337)
+	    // Extract a request-scoped zap.Logger and log a message.
+	    grpc_logrus.Extract(ctx).Info("some ping")
+	    return &pb_testproto.PingResponse{Value: ping.Value}, nil
+	}
+	return x
+```
+
+</details>
+
+#### Example:
+
+<details>
+<summary>Click to expand code.</summary>
+
+```go
+// Logrus entry is used, allowing pre-definition of certain fields by the user.
+	logrusEntry := logrus.NewEntry(logrusLogger)
+	// Shared options for the logger, with a custom gRPC code to log level function.
+	opts := []grpc_logrus.Option{
+	    grpc_logrus.WithLevels(customFunc),
+	}
+	// Make sure that log statements internal to gRPC library are logged using the zapLogger as well.
+	grpc_logrus.ReplaceGrpcLogger(logrusEntry)
+	// Create a server, make sure we put the grpc_ctxtags context before everything else.
+	server := grpc.NewServer(
+	    grpc_middleware.WithUnaryServerChain(
+	        grpc_ctxtags.UnaryServerInterceptor(grpc_ctxtags.WithFieldExtractor(grpc_ctxtags.CodeGenRequestFieldExtractor)),
+	        grpc_logrus.UnaryServerInterceptor(logrusEntry, opts...),
+	    ),
+	    grpc_middleware.WithStreamServerChain(
+	        grpc_ctxtags.StreamServerInterceptor(grpc_ctxtags.WithFieldExtractor(grpc_ctxtags.CodeGenRequestFieldExtractor)),
+	        grpc_logrus.StreamServerInterceptor(logrusEntry, opts...),
+	    ),
+	)
+	return server
+```
+
+</details>
+
+#### Example:
+
+<details>
+<summary>Click to expand code.</summary>
+
+```go
+// Logrus entry is used, allowing pre-definition of certain fields by the user.
+	logrusEntry := logrus.NewEntry(logrusLogger)
+	// Shared options for the logger, with a custom duration to log field function.
+	opts := []grpc_logrus.Option{
+	    grpc_logrus.WithDurationField(func(duration time.Duration) (key string, value interface{}) {
+	        return "grpc.time_ns", duration.Nanoseconds()
+	    }),
+	}
+	server := grpc.NewServer(
+	    grpc_middleware.WithUnaryServerChain(
+	        grpc_ctxtags.UnaryServerInterceptor(),
+	        grpc_logrus.UnaryServerInterceptor(logrusEntry, opts...),
+	    ),
+	    grpc_middleware.WithStreamServerChain(
+	        grpc_ctxtags.StreamServerInterceptor(),
+	        grpc_logrus.StreamServerInterceptor(logrusEntry, opts...),
+	    ),
+	)
+	return server
+```
+
+</details>
+
 ## <a name="pkg-imports">Imported Packages</a>
 
 - github.com/Sirupsen/logrus

--- a/logging/logrus/doc.go
+++ b/logging/logrus/doc.go
@@ -10,6 +10,11 @@ It accepts a user-configured `logrus.Entry` that will be used for logging comple
 You can use `Extract` to log into a request-scoped `logrus.Entry` instance in your handler code. The fields set on the
 logger correspond to the grpc_ctxtags.Tags attached to the context.
 
+This package also implements request and response *payload* logging, both for server-side and client-side. These will be
+logged as structured `jsonbp` fields for every message received/sent (both unary and streaming). For that please use
+`Payload*Interceptor` functions for that. Please note that the user-provided function that determines whetether to log
+the full request/response payload needs to be written with care, this can significantly slow down gRPC.
+
 Logrus can also be made as a backend for gRPC library internals. For that use `ReplaceGrpcLogger`.
 
 Please see examples and tests for examples of use.

--- a/logging/zap/DOC.md
+++ b/logging/zap/DOC.md
@@ -15,6 +15,11 @@ be used for logging completed gRPC calls, and be populated into the `context.Con
 You can use `Extract` to log into a request-scoped `zap.Logger` instance in your handler code. The fields set on the
 logger correspond to the grpc_ctxtags.Tags attached to the context.
 
+This package also implements request and response *payload* logging, both for server-side and client-side. These will be
+logged as structured `jsonbp` fields for every message received/sent (both unary and streaming). For that please use
+`Payload*Interceptor` functions for that. Please note that the user-provided function that determines whetether to log
+the full request/response payload needs to be written with care, this can significantly slow down gRPC.
+
 ZAP can also be made as a backend for gRPC library internals. For that use `ReplaceGrpcLogger`.
 
 Please see examples and tests for examples of use.

--- a/logging/zap/doc.go
+++ b/logging/zap/doc.go
@@ -10,6 +10,11 @@ be used for logging completed gRPC calls, and be populated into the `context.Con
 You can use `Extract` to log into a request-scoped `zap.Logger` instance in your handler code. The fields set on the
 logger correspond to the grpc_ctxtags.Tags attached to the context.
 
+This package also implements request and response *payload* logging, both for server-side and client-side. These will be
+logged as structured `jsonbp` fields for every message received/sent (both unary and streaming). For that please use
+`Payload*Interceptor` functions for that. Please note that the user-provided function that determines whetether to log
+the full request/response payload needs to be written with care, this can significantly slow down gRPC.
+
 ZAP can also be made as a backend for gRPC library internals. For that use `ReplaceGrpcLogger`.
 
 Please see examples and tests for examples of use.

--- a/recovery/DOC.md
+++ b/recovery/DOC.md
@@ -7,7 +7,7 @@
 * [Examples](#pkg-examples)
 
 ## <a name="pkg-overview">Overview</a>
-`grpc_recovery` conversion of panics into gRPC errors
+`grpc_recovery` are intereceptors that recover from gRPC handler panics.
 
 ### Server Side Recovery Middleware
 By default a panic will be converted into a gRPC error with `code.Internal`.

--- a/recovery/DOC.md
+++ b/recovery/DOC.md
@@ -16,6 +16,31 @@ Handling can be customised by providing an alternate recovery function.
 
 Please see examples for simple examples of use.
 
+#### Example:
+
+<details>
+<summary>Click to expand code.</summary>
+
+```go
+// Shared options for the logger, with a custom gRPC code to log level function.
+	opts := []grpc_recovery.Option{
+	    grpc_recovery.WithRecoveryHandler(customFunc),
+	}
+	// Create a server. Recovery handlers should typically be last in the chain so that other middleware
+	// (e.g. logging) can operate on the recovered state instead of being directly affected by any panic
+	server := grpc.NewServer(
+	    grpc_middleware.WithUnaryServerChain(
+	        grpc_recovery.UnaryServerInterceptor(opts...),
+	    ),
+	    grpc_middleware.WithStreamServerChain(
+	        grpc_recovery.StreamServerInterceptor(opts...),
+	    ),
+	)
+	return server
+```
+
+</details>
+
 ## <a name="pkg-imports">Imported Packages</a>
 
 - [golang.org/x/net/context](https://godoc.org/golang.org/x/net/context)

--- a/recovery/doc.go
+++ b/recovery/doc.go
@@ -2,7 +2,7 @@
 // See LICENSE for licensing terms.
 
 /*
-`grpc_recovery` conversion of panics into gRPC errors
+`grpc_recovery` are intereceptors that recover from gRPC handler panics.
 
 Server Side Recovery Middleware
 

--- a/retry/DOC.md
+++ b/retry/DOC.md
@@ -23,6 +23,84 @@ linear backoff with 10% jitter.
 
 Please see examples for more advanced use.
 
+#### Example:
+
+<details>
+<summary>Click to expand code.</summary>
+
+```go
+client := pb_testproto.NewTestServiceClient(cc)
+	pong, err := client.Ping(
+	    newCtx(5*time.Second),
+	    &pb_testproto.PingRequest{},
+	    grpc_retry.WithMax(3),
+	    grpc_retry.WithPerRetryTimeout(1*time.Second))
+	if err != nil {
+	    return err
+	}
+	fmt.Printf("got pong: %v", pong)
+	return nil
+```
+
+</details>
+
+#### Example:
+
+<details>
+<summary>Click to expand code.</summary>
+
+```go
+opts := []grpc_retry.CallOption{
+	    grpc_retry.WithBackoff(grpc_retry.BackoffLinear(100 * time.Millisecond)),
+	    grpc_retry.WithCodes(codes.NotFound, codes.Aborted),
+	}
+	return grpc.Dial("myservice.example.com",
+	    grpc.WithStreamInterceptor(grpc_retry.StreamClientInterceptor(opts...)),
+	    grpc.WithUnaryInterceptor(grpc_retry.UnaryClientInterceptor(opts...)),
+	)
+```
+
+</details>
+
+#### Example:
+
+<details>
+<summary>Click to expand code.</summary>
+
+```go
+return grpc.Dial("myservice.example.com",
+	    grpc.WithStreamInterceptor(grpc_retry.StreamClientInterceptor()),
+	    grpc.WithUnaryInterceptor(grpc_retry.UnaryClientInterceptor()),
+	)
+```
+
+</details>
+
+#### Example:
+
+<details>
+<summary>Click to expand code.</summary>
+
+```go
+client := pb_testproto.NewTestServiceClient(cc)
+	stream, err := client.PingList(newCtx(1*time.Second), &pb_testproto.PingRequest{}, grpc_retry.WithMax(3))
+	if err != nil {
+	    return err
+	}
+	for {
+	    pong, err := stream.Recv() // retries happen here
+	    if err == io.EOF {
+	        break
+	    } else if err != nil {
+	        return err
+	    }
+	    fmt.Printf("got pong: %v", pong)
+	}
+	return nil
+```
+
+</details>
+
 ## <a name="pkg-imports">Imported Packages</a>
 
 - [github.com/grpc-ecosystem/go-grpc-middleware/util/backoffutils](./../util/backoffutils)

--- a/tags/DOC.md
+++ b/tags/DOC.md
@@ -7,6 +7,20 @@
 * [Examples](#pkg-examples)
 
 ## <a name="pkg-overview">Overview</a>
+`grpc_ctxtags` adds a Tag object to the context that can be used by other middleware to add context about a request.
+
+### Request Context Tags
+Tags describe information about the request, and can be set and used by other middleware, or handlers. Tags are used
+for logging and tracing of requests. Tags are populated both upwards, *and* downwards in the interceptor-handler stack.
+
+You can automatically extract tags (in `grpc.request.<field_name>`) from request payloads (in unary and server-streaming)
+by passing in the `WithFieldExtractor` option.
+
+If a user doesn't use the interceptors that initialize the `Tags` object, all operations following from an `Extract(ctx)`
+will be no-ops. This is to ensure that code doesn't panic if the interceptors weren't used.
+
+Tags fields are typed, and shallow and should follow the OpenTracing semantics convention:
+<a href="https://github.com/opentracing/specification/blob/master/semantic_conventions.md">https://github.com/opentracing/specification/blob/master/semantic_conventions.md</a>
 
 #### Example:
 

--- a/tags/DOC.md
+++ b/tags/DOC.md
@@ -8,6 +8,24 @@
 
 ## <a name="pkg-overview">Overview</a>
 
+#### Example:
+
+<details>
+<summary>Click to expand code.</summary>
+
+```go
+opts := []grpc_ctxtags.Option{
+	    grpc_ctxtags.WithFieldExtractor(grpc_ctxtags.TagBasedRequestFieldExtractor("log_fields")),
+	}
+	server := grpc.NewServer(
+	    grpc.StreamInterceptor(grpc_ctxtags.StreamServerInterceptor(opts...)),
+	    grpc.UnaryInterceptor(grpc_ctxtags.UnaryServerInterceptor(opts...)),
+	)
+	return server
+```
+
+</details>
+
 ## <a name="pkg-imports">Imported Packages</a>
 
 - [github.com/grpc-ecosystem/go-grpc-middleware](./..)

--- a/tags/doc.go
+++ b/tags/doc.go
@@ -2,7 +2,7 @@
 // See LICENSE for licensing terms.
 
 /*
-`grpc_ctxtags` adds a Tag object to the context that can be used by other middleware to add context about a request
+`grpc_ctxtags` adds a Tag object to the context that can be used by other middleware to add context about a request.
 
 Request Context Tags
 
@@ -17,7 +17,5 @@ will be no-ops. This is to ensure that code doesn't panic if the interceptors we
 
 Tags fields are typed, and shallow and should follow the OpenTracing semantics convention:
 https://github.com/opentracing/specification/blob/master/semantic_conventions.md
-
 */
-
 package grpc_ctxtags

--- a/tracing/opentracing/DOC.md
+++ b/tracing/opentracing/DOC.md
@@ -6,6 +6,20 @@
 * [Index](#pkg-index)
 
 ## <a name="pkg-overview">Overview</a>
+`grpc_opentracing` adds OpenTracing
+
+### OpenTracing Interceptors
+These are both client-side and server-side interceptors for OpenTracing. They are a provider-agnostic, with backends
+such as Zipkin, or Google Stackdriver Trace.
+
+For a service that sends out requests and receives requests, you *need* to use both, otherwise downstream requests will
+not have the appropriate requests propagated.
+
+All server-side spans are tagged with grpc_ctxtags information.
+
+For more information see:
+<a href="http://opentracing.io/documentation/">http://opentracing.io/documentation/</a>
+<a href="https://github.com/opentracing/specification/blob/master/semantic_conventions.md">https://github.com/opentracing/specification/blob/master/semantic_conventions.md</a>
 
 ## <a name="pkg-imports">Imported Packages</a>
 

--- a/tracing/opentracing/doc.go
+++ b/tracing/opentracing/doc.go
@@ -19,5 +19,4 @@ http://opentracing.io/documentation/
 https://github.com/opentracing/specification/blob/master/semantic_conventions.md
 
 */
-
 package grpc_opentracing


### PR DESCRIPTION
This causes `examples_test` stuff to land inside the DOC.md.