### PR TITLE
Minor typo in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 [gRPC Go](https://github.com/grpc/grpc-go) recently acquired support for
 Interceptors, i.e. [middleware](https://medium.com/@matryer/writing-middleware-in-golang-and-how-go-makes-it-so-much-fun-4375c1246e81#.gv7tdlghs) 
 that is executed either on the gRPC Server before the request is passed onto the user's application logic, or on the gRPC client either around the user call. It is a perfect way to implement
-common patters: auth, logging, message, validation, retries or monitoring.
+common patterns: auth, logging, message, validation, retries or monitoring.
 
 These are generic building blocks that make it easy to build multiple microservices easily.
 The purpose of this repository is to act as a go-to point for such reusable functionality. It contains


### PR DESCRIPTION
There was a small typo in the readme that was bothering me.

So I added an `n` to `patters`

Apologies for the one character commit...

