### PR TITLE
return error status proto in unary interceptor

### DIFF
--- a/logging/zap/options.go
+++ b/logging/zap/options.go
@@ -17,6 +17,7 @@ var (
 		levelFunc:    DefaultCodeToLevel,
 		codeFunc:     grpc_logging.DefaultErrorToCode,
 		durationFunc: DefaultDurationToField,
+		statusInfo:   false,
 	}
 )
 
@@ -24,6 +25,7 @@ type options struct {
 	levelFunc    CodeToLevel
 	codeFunc     grpc_logging.ErrorToCode
 	durationFunc DurationToField
+	statusInfo   bool
 }
 
 func evaluateServerOpt(opts []Option) *options {
@@ -72,6 +74,13 @@ func WithCodes(f grpc_logging.ErrorToCode) Option {
 func WithDurationField(f DurationToField) Option {
 	return func(o *options) {
 		o.durationFunc = f
+	}
+}
+
+// WithStatusInfo customizes the function logs errors with google.rpc.Status message.
+func WithStatusInfo() Option {
+	return func(o *options) {
+		o.statusInfo = true
 	}
 }
 

--- a/logging/zap/shared_test.go
+++ b/logging/zap/shared_test.go
@@ -17,6 +17,7 @@ import (
 
 var (
 	goodPing = &pb_testproto.PingRequest{Value: "something", SleepTimeMs: 9999}
+	badPing  = &pb_testproto.PingRequest{Value: "something", SleepTimeMs: 9999, ErrorCodeReturned: 3}
 )
 
 type loggingPingService struct {


### PR DESCRIPTION
Payload interceptor does not dump anything on error currently.
From grpc-go v1.3, status package was introduced and we can extract status proto from error. The proto also contains additional fields `datails`.
Now it is better to dump error response with proto status in paylaod interceptor.
zap for unary interceptor is only implemeneted for now.