### PR TITLE
Renamed github.com/Sirupsen/logrus to github.com/sirupsen/logrus

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ install:
   # for logs/zap
   - go get go.uber.org/zap
   # for logs/logrus
-  - go get github.com/Sirupsen/logrus
+  - go get github.com/sirupsen/logrus
   # for field testing
   - go get github.com/gogo/protobuf/proto
   # for tracing/opentracing

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ myServer := grpc.NewServer(
 #### Logging
    * [`grpc_ctxtags`](tags/) - a library that adds a `Tag` map to context, with data populated from request body
    * [`grpc_zap`](logging/zap/) - integration of [zap](https://github.com/uber-go/zap) logging library into gRPC handlers.
-   * [`grpc_logrus`](logging/logrus/) - integration of [logrus](https://github.com/Sirupsen/logrus) logging library into gRPC handlers.
+   * [`grpc_logrus`](logging/logrus/) - integration of [logrus](https://github.com/sirupsen/logrus) logging library into gRPC handlers.
 
 
 #### Monitoring

--- a/logging/logrus/DOC.md
+++ b/logging/logrus/DOC.md
@@ -103,7 +103,7 @@ x := func(ctx context.Context, ping *pb_testproto.PingRequest) (*pb_testproto.Pi
 
 ## <a name="pkg-imports">Imported Packages</a>
 
-- github.com/Sirupsen/logrus
+- github.com/sirupsen/logrus
 - [github.com/golang/protobuf/jsonpb](https://godoc.org/github.com/golang/protobuf/jsonpb)
 - [github.com/golang/protobuf/proto](https://godoc.org/github.com/golang/protobuf/proto)
 - [github.com/grpc-ecosystem/go-grpc-middleware](./../..)

--- a/logging/logrus/client_interceptors.go
+++ b/logging/logrus/client_interceptors.go
@@ -7,7 +7,7 @@ import (
 	"path"
 	"time"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 )

--- a/logging/logrus/client_interceptors_test.go
+++ b/logging/logrus/client_interceptors_test.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/logging/logrus/context.go
+++ b/logging/logrus/context.go
@@ -4,7 +4,7 @@
 package grpc_logrus
 
 import (
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/grpc-ecosystem/go-grpc-middleware/tags"
 	"golang.org/x/net/context"
 )

--- a/logging/logrus/examples_test.go
+++ b/logging/logrus/examples_test.go
@@ -6,7 +6,7 @@ package grpc_logrus_test
 import (
 	"time"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/logrus"
 
 	"github.com/grpc-ecosystem/go-grpc-middleware"

--- a/logging/logrus/grpclogger.go
+++ b/logging/logrus/grpclogger.go
@@ -4,7 +4,7 @@
 package grpc_logrus
 
 import (
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc/grpclog"
 )
 

--- a/logging/logrus/noop.go
+++ b/logging/logrus/noop.go
@@ -3,7 +3,7 @@ package grpc_logrus
 import (
 	"io/ioutil"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 var (

--- a/logging/logrus/options.go
+++ b/logging/logrus/options.go
@@ -6,7 +6,7 @@ package grpc_logrus
 import (
 	"time"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging"
 	"google.golang.org/grpc/codes"
 )

--- a/logging/logrus/payload_interceptors.go
+++ b/logging/logrus/payload_interceptors.go
@@ -8,7 +8,7 @@ import (
 
 	"fmt"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/golang/protobuf/jsonpb"
 	"github.com/golang/protobuf/proto"
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging"

--- a/logging/logrus/payload_interceptors_test.go
+++ b/logging/logrus/payload_interceptors_test.go
@@ -16,7 +16,7 @@ import (
 
 	"io"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/grpc-ecosystem/go-grpc-middleware"
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/logrus"
 	"github.com/grpc-ecosystem/go-grpc-middleware/tags"

--- a/logging/logrus/server_interceptors.go
+++ b/logging/logrus/server_interceptors.go
@@ -7,7 +7,7 @@ import (
 	"path"
 	"time"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/grpc-ecosystem/go-grpc-middleware"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"

--- a/logging/logrus/server_interceptors_test.go
+++ b/logging/logrus/server_interceptors_test.go
@@ -16,7 +16,7 @@ import (
 
 	"strings"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/grpc-ecosystem/go-grpc-middleware"
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/logrus"
 	"github.com/grpc-ecosystem/go-grpc-middleware/tags"

--- a/logging/logrus/shared_test.go
+++ b/logging/logrus/shared_test.go
@@ -7,7 +7,7 @@ import (
 
 	"testing"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/logrus"
 	"github.com/grpc-ecosystem/go-grpc-middleware/tags"
 	"github.com/grpc-ecosystem/go-grpc-middleware/testing"


### PR DESCRIPTION
The package github.com/Sirupsen/logrus has been renamed to github.com/sirupsen/logrus. This PR updates all references to the new, lowercase name.

From https://github.com/sirupsen/logrus/blob/master/README.md#case-sensitivity:

> The organization's name was changed to lower-case--and this will not be changed back. If you are getting import conflicts due to case sensitivity, please use the lower-case import: github.com/sirupsen/logrus.