### PR TITLE
Use EmptyOption for retry interceptor

### DIFF
--- a/retry/options.go
+++ b/retry/options.go
@@ -92,7 +92,7 @@ type options struct {
 
 // callOption is a grpc.CallOption that is local to grpc_retry.
 type CallOption struct {
-	grpc.CallOption // anonymously implement it, without knowing the private fields.
+	grpc.EmptyCallOption // make sure we implement private after() and before() fields so we don't panic.
 	applyFunc       func(opt *options)
 }
 


### PR DESCRIPTION
Fixes issue #37.

Adds dependency on gRPC-Go 1.4

@yifanzz