### PR TITLE
simplify buildChain logic

### DIFF
--- a/chain.go
+++ b/chain.go
@@ -16,27 +16,18 @@ import (
 // For example ChainUnaryServer(one, two, three) will execute one before two before three, and three
 // will see context changes of one and two.
 func ChainUnaryServer(interceptors ...grpc.UnaryServerInterceptor) grpc.UnaryServerInterceptor {
-	switch len(interceptors) {
-	case 0:
-		// do not want to return nil interceptor since this function was never defined to do so/for backwards compatibility
-		return func(ctx context.Context, req interface{}, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
-			return handler(ctx, req)
-		}
-	case 1:
-		return interceptors[0]
-	default:
-		return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
-			buildChain := func(current grpc.UnaryServerInterceptor, next grpc.UnaryHandler) grpc.UnaryHandler {
-				return func(currentCtx context.Context, currentReq interface{}) (interface{}, error) {
-					return current(currentCtx, currentReq, info, next)
-				}
+	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+		buildChain := func(current grpc.UnaryServerInterceptor, next grpc.UnaryHandler) grpc.UnaryHandler {
+			return func(currentCtx context.Context, currentReq interface{}) (interface{}, error) {
+				return current(currentCtx, currentReq, info, next)
 			}
-			chain := handler
-			for i := len(interceptors) - 1; i >= 0; i-- {
-				chain = buildChain(interceptors[i], chain)
-			}
-			return chain(ctx, req)
 		}
+
+		chain := handler
+		for i := len(interceptors) - 1; i >= 0; i-- {
+			chain = buildChain(interceptors[i], chain)
+		}
+		return chain(ctx, req)
 	}
 }
 
@@ -46,27 +37,18 @@ func ChainUnaryServer(interceptors ...grpc.UnaryServerInterceptor) grpc.UnarySer
 // For example ChainUnaryServer(one, two, three) will execute one before two before three.
 // If you want to pass context between interceptors, use WrapServerStream.
 func ChainStreamServer(interceptors ...grpc.StreamServerInterceptor) grpc.StreamServerInterceptor {
-	switch len(interceptors) {
-	case 0:
-		// do not want to return nil interceptor since this function was never defined to do so/for backwards compatibility
-		return func(srv interface{}, stream grpc.ServerStream, _ *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
-			return handler(srv, stream)
-		}
-	case 1:
-		return interceptors[0]
-	default:
-		return func(srv interface{}, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
-			buildChain := func(current grpc.StreamServerInterceptor, next grpc.StreamHandler) grpc.StreamHandler {
-				return func(currentSrv interface{}, currentStream grpc.ServerStream) error {
-					return current(currentSrv, currentStream, info, next)
-				}
+	return func(srv interface{}, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		buildChain := func(current grpc.StreamServerInterceptor, next grpc.StreamHandler) grpc.StreamHandler {
+			return func(currentSrv interface{}, currentStream grpc.ServerStream) error {
+				return current(currentSrv, currentStream, info, next)
 			}
-			chain := handler
-			for i := len(interceptors) - 1; i >= 0; i-- {
-				chain = buildChain(interceptors[i], chain)
-			}
-			return chain(srv, stream)
 		}
+
+		chain := handler
+		for i := len(interceptors) - 1; i >= 0; i-- {
+			chain = buildChain(interceptors[i], chain)
+		}
+		return chain(srv, stream)
 	}
 }
 
@@ -75,27 +57,18 @@ func ChainStreamServer(interceptors ...grpc.StreamServerInterceptor) grpc.Stream
 // Execution is done in left-to-right order, including passing of context.
 // For example ChainUnaryClient(one, two, three) will execute one before two before three.
 func ChainUnaryClient(interceptors ...grpc.UnaryClientInterceptor) grpc.UnaryClientInterceptor {
-	switch len(interceptors) {
-	case 0:
-		// do not want to return nil interceptor since this function was never defined to do so/for backwards compatibility
-		return func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
-			return invoker(ctx, method, req, reply, cc, opts...)
-		}
-	case 1:
-		return interceptors[0]
-	default:
-		return func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
-			buildChain := func(current grpc.UnaryClientInterceptor, next grpc.UnaryInvoker) grpc.UnaryInvoker {
-				return func(currentCtx context.Context, currentMethod string, currentReq, currentRepl interface{}, currentConn *grpc.ClientConn, currentOpts ...grpc.CallOption) error {
-					return current(currentCtx, currentMethod, currentReq, currentRepl, currentConn, next, currentOpts...)
-				}
+	return func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+		buildChain := func(current grpc.UnaryClientInterceptor, next grpc.UnaryInvoker) grpc.UnaryInvoker {
+			return func(currentCtx context.Context, currentMethod string, currentReq, currentRepl interface{}, currentConn *grpc.ClientConn, currentOpts ...grpc.CallOption) error {
+				return current(currentCtx, currentMethod, currentReq, currentRepl, currentConn, next, currentOpts...)
 			}
-			chain := invoker
-			for i := len(interceptors) - 1; i >= 0; i-- {
-				chain = buildChain(interceptors[i], chain)
-			}
-			return chain(ctx, method, req, reply, cc, opts...)
 		}
+
+		chain := invoker
+		for i := len(interceptors) - 1; i >= 0; i-- {
+			chain = buildChain(interceptors[i], chain)
+		}
+		return chain(ctx, method, req, reply, cc, opts...)
 	}
 }
 
@@ -104,27 +77,18 @@ func ChainUnaryClient(interceptors ...grpc.UnaryClientInterceptor) grpc.UnaryCli
 // Execution is done in left-to-right order, including passing of context.
 // For example ChainStreamClient(one, two, three) will execute one before two before three.
 func ChainStreamClient(interceptors ...grpc.StreamClientInterceptor) grpc.StreamClientInterceptor {
-	switch len(interceptors) {
-	case 0:
-		// do not want to return nil interceptor since this function was never defined to do so/for backwards compatibility
-		return func(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string, streamer grpc.Streamer, opts ...grpc.CallOption) (grpc.ClientStream, error) {
-			return streamer(ctx, desc, cc, method, opts...)
-		}
-	case 1:
-		return interceptors[0]
-	default:
-		return func(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string, streamer grpc.Streamer, opts ...grpc.CallOption) (grpc.ClientStream, error) {
-			buildChain := func(current grpc.StreamClientInterceptor, next grpc.Streamer) grpc.Streamer {
-				return func(currentCtx context.Context, currentDesc *grpc.StreamDesc, currentConn *grpc.ClientConn, currentMethod string, currentOpts ...grpc.CallOption) (grpc.ClientStream, error) {
-					return current(currentCtx, currentDesc, currentConn, currentMethod, next, currentOpts...)
-				}
+	return func(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string, streamer grpc.Streamer, opts ...grpc.CallOption) (grpc.ClientStream, error) {
+		buildChain := func(current grpc.StreamClientInterceptor, next grpc.Streamer) grpc.Streamer {
+			return func(currentCtx context.Context, currentDesc *grpc.StreamDesc, currentConn *grpc.ClientConn, currentMethod string, currentOpts ...grpc.CallOption) (grpc.ClientStream, error) {
+				return current(currentCtx, currentDesc, currentConn, currentMethod, next, currentOpts...)
 			}
-			chain := streamer
-			for i := len(interceptors) - 1; i >= 0; i-- {
-				chain = buildChain(interceptors[i], chain)
-			}
-			return chain(ctx, desc, cc, method, opts...)
 		}
+
+		chain := streamer
+		for i := len(interceptors) - 1; i >= 0; i-- {
+			chain = buildChain(interceptors[i], chain)
+		}
+		return chain(ctx, desc, cc, method, opts...)
 	}
 }
 


### PR DESCRIPTION
The previous logic is based on len(interceptors). However, the default
case can handle all the case. To remove the case check can make
buildChain clear.

@mwitkow 