### PR TITLE
s/WithPerCallTimeout/WithPerRetryTimeout/g

### DIFF
--- a/retry/DOC.md
+++ b/retry/DOC.md
@@ -246,9 +246,9 @@ func WithPerRetryTimeout(timeout time.Duration) CallOption
 WithPerRetryTimeout sets the RPC timeout per call (including initial call) on this call, or this interceptor.
 
 The context.Deadline of the call takes precedence and sets the maximum time the whole invocation
-will take, but WithPerCallTimeout can be used to limit the RPC time per each call.
+will take, but WithPerRetryTimeout can be used to limit the RPC time per each call.
 
-For example, with context.Deadline = now + 10s, and WithPerCallTimeout(3 * time.Seconds), each
+For example, with context.Deadline = now + 10s, and WithPerRetryTimeout(3 * time.Seconds), each
 of the retry calls (including the initial one) will have a deadline of now + 3s.
 
 A value of 0 disables the timeout overrides completely and returns to each retry call using the

--- a/retry/options.go
+++ b/retry/options.go
@@ -69,9 +69,9 @@ func WithCodes(retryCodes ...codes.Code) CallOption {
 // WithPerRetryTimeout sets the RPC timeout per call (including initial call) on this call, or this interceptor.
 //
 // The context.Deadline of the call takes precedence and sets the maximum time the whole invocation
-// will take, but WithPerCallTimeout can be used to limit the RPC time per each call.
+// will take, but WithPerRetryTimeout can be used to limit the RPC time per each call.
 //
-// For example, with context.Deadline = now + 10s, and WithPerCallTimeout(3 * time.Seconds), each
+// For example, with context.Deadline = now + 10s, and WithPerRetryTimeout(3 * time.Seconds), each
 // of the retry calls (including the initial one) will have a deadline of now + 3s.
 //
 // A value of 0 disables the timeout overrides completely and returns to each retry call using the


### PR DESCRIPTION
Function name is wrong in retry package.