### PR TITLE
grpc_ctxtags: Tagging on client streamed requests

### DIFF
--- a/tags/doc.go
+++ b/tags/doc.go
@@ -9,8 +9,12 @@ Request Context Tags
 Tags describe information about the request, and can be set and used by other middleware, or handlers. Tags are used
 for logging and tracing of requests. Tags are populated both upwards, *and* downwards in the interceptor-handler stack.
 
-You can automatically extract tags (in `grpc.request.<field_name>`) from request payloads (in unary and server-streaming)
-by passing in the `WithFieldExtractor` option.
+You can automatically extract tags (in `grpc.request.<field_name>`) from request payloads.
+
+For unary and server-streaming methods, pass in the `WithFieldExtractor` option. For client-streams and bidirectional-streams, you can
+use `WithFieldExtractorForInitialReq` which will extract the tags from the first message passed from client to server.
+Note the tags will not be modified for subsequent requests, so this option only makes sense when the initial message
+establishes the meta-data for the stream.
 
 If a user doesn't use the interceptors that initialize the `Tags` object, all operations following from an `Extract(ctx)`
 will be no-ops. This is to ensure that code doesn't panic if the interceptors weren't used.

--- a/tags/examples_test.go
+++ b/tags/examples_test.go
@@ -19,3 +19,16 @@ func Example_initialization() *grpc.Server {
 	)
 	return server
 }
+
+// Example using WithFieldExtractorForInitialReq
+func Example_initialization_forInitialReq() *grpc.Server {
+	opts := []grpc_ctxtags.Option{
+		grpc_ctxtags.WithFieldExtractorForInitialReq(grpc_ctxtags.TagBasedRequestFieldExtractor("log_fields")),
+	}
+	server := grpc.NewServer(
+		grpc.StreamInterceptor(grpc_ctxtags.StreamServerInterceptor(opts...)),
+		grpc.UnaryInterceptor(grpc_ctxtags.UnaryServerInterceptor(opts...)),
+	)
+
+	return server
+}

--- a/tags/interceptors.go
+++ b/tags/interceptors.go
@@ -33,7 +33,7 @@ func StreamServerInterceptor(opts ...Option) grpc.StreamServerInterceptor {
 			wrappedStream.WrappedContext = newCtx
 			return handler(srv, wrappedStream)
 		}
-		wrapped := &wrappedStream{stream, info, o, newCtx}
+		wrapped := &wrappedStream{stream, info, o, newCtx, true}
 		err := handler(srv, wrapped)
 		return err
 	}
@@ -46,6 +46,7 @@ type wrappedStream struct {
 	opts *options
 	// WrappedContext is the wrapper's own Context. You can assign it.
 	WrappedContext context.Context
+	initial        bool
 }
 
 // Context returns the wrapper's WrappedContext, overwriting the nested grpc.ServerStream.Context()
@@ -56,7 +57,9 @@ func (w *wrappedStream) Context() context.Context {
 func (w *wrappedStream) RecvMsg(m interface{}) error {
 	err := w.ServerStream.RecvMsg(m)
 	// We only do log fields extraction on the single-reqest of a server-side stream.
-	if !w.info.IsClientStream {
+	if !w.info.IsClientStream || w.opts.requestFieldsFromInitial && w.initial {
+		w.initial = false
+
 		setRequestFieldTags(w.Context(), w.opts.requestFieldsFunc, w.info.FullMethod, m)
 	}
 	return err

--- a/tags/options.go
+++ b/tags/options.go
@@ -10,7 +10,8 @@ var (
 )
 
 type options struct {
-	requestFieldsFunc RequestFieldExtractorFunc
+	requestFieldsFunc        RequestFieldExtractorFunc
+	requestFieldsFromInitial bool
 }
 
 func evaluateOptions(opts []Option) *options {
@@ -24,9 +25,20 @@ func evaluateOptions(opts []Option) *options {
 
 type Option func(*options)
 
-// WithFieldExtractor customizes the function for extracting log fields from protobuf messages.
+// WithFieldExtractor customizes the function for extracting log fields from protobuf messages, for
+// unary and server-streamed methods only.
 func WithFieldExtractor(f RequestFieldExtractorFunc) Option {
 	return func(o *options) {
 		o.requestFieldsFunc = f
+	}
+}
+
+// WithFieldExtractorForInitialReq customizes the function for extracting log fields from protobuf messages,
+// for all unary and streaming methods. For client-streams and bidirectional-streams, the tags will be
+// extracted from the first message from the client.
+func WithFieldExtractorForInitialReq(f RequestFieldExtractorFunc) Option {
+	return func(o *options) {
+		o.requestFieldsFunc = f
+		o.requestFieldsFromInitial = true
 	}
 }


### PR DESCRIPTION
This change provides the option for client streaming bidirectional requests to be used to tag the context. 

When enabled, the first incoming client streamed request is used to set the context tags. We use it for streamed requests such as this one: https://gitlab.com/gitlab-org/gitaly-proto/blob/master/ssh.proto#L9

It can be configured using the `grpc_ctxtags.WithFieldExtractorForInitialReq`  option. (I would love a suggestion for a better name, if you have one)


```golang
opts := []grpc_ctxtags.Option{
	grpc_ctxtags.WithFieldExtractorForInitialReq(grpc_ctxtags.CodeGenRequestFieldExtractor),
}
```

Thanks for such a fantastically helpful library!