### PR TITLE
Refactored middleware chain builders

### DIFF
--- a/chain.go
+++ b/chain.go
@@ -16,27 +16,35 @@ import (
 // For example ChainUnaryServer(one, two, three) will execute one before two before three, and three
 // will see context changes of one and two.
 func ChainUnaryServer(interceptors ...grpc.UnaryServerInterceptor) grpc.UnaryServerInterceptor {
-	switch len(interceptors) {
-	case 0:
-		// do not want to return nil interceptor since this function was never defined to do so/for backwards compatibility
-		return func(ctx context.Context, req interface{}, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
-			return handler(ctx, req)
-		}
-	case 1:
-		return interceptors[0]
-	default:
+	n := len(interceptors)
+
+	if n > 1 {
+		lastI := n - 1
 		return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
-			buildChain := func(current grpc.UnaryServerInterceptor, next grpc.UnaryHandler) grpc.UnaryHandler {
-				return func(currentCtx context.Context, currentReq interface{}) (interface{}, error) {
-					return current(currentCtx, currentReq, info, next)
+			var (
+				chainHandler grpc.UnaryHandler
+				curI         int
+			)
+
+			chainHandler = func(currentCtx context.Context, currentReq interface{}) (interface{}, error) {
+				if curI == lastI {
+					return handler(currentCtx, currentReq)
 				}
+				curI++
+				return interceptors[curI](currentCtx, currentReq, info, chainHandler)
 			}
-			chain := handler
-			for i := len(interceptors) - 1; i >= 0; i-- {
-				chain = buildChain(interceptors[i], chain)
-			}
-			return chain(ctx, req)
+
+			return interceptors[0](ctx, req, info, chainHandler)
 		}
+	}
+
+	if n == 1 {
+		return interceptors[0]
+	}
+
+	// n == 0; Dummy interceptor maintained for backward compatibility to avoid returning nil.
+	return func(ctx context.Context, req interface{}, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+		return handler(ctx, req)
 	}
 }
 
@@ -46,27 +54,35 @@ func ChainUnaryServer(interceptors ...grpc.UnaryServerInterceptor) grpc.UnarySer
 // For example ChainUnaryServer(one, two, three) will execute one before two before three.
 // If you want to pass context between interceptors, use WrapServerStream.
 func ChainStreamServer(interceptors ...grpc.StreamServerInterceptor) grpc.StreamServerInterceptor {
-	switch len(interceptors) {
-	case 0:
-		// do not want to return nil interceptor since this function was never defined to do so/for backwards compatibility
-		return func(srv interface{}, stream grpc.ServerStream, _ *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
-			return handler(srv, stream)
-		}
-	case 1:
-		return interceptors[0]
-	default:
+	n := len(interceptors)
+
+	if n > 1 {
+		lastI := n - 1
 		return func(srv interface{}, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
-			buildChain := func(current grpc.StreamServerInterceptor, next grpc.StreamHandler) grpc.StreamHandler {
-				return func(currentSrv interface{}, currentStream grpc.ServerStream) error {
-					return current(currentSrv, currentStream, info, next)
+			var (
+				chainHandler grpc.StreamHandler
+				curI         int
+			)
+
+			chainHandler = func(currentSrv interface{}, currentStream grpc.ServerStream) error {
+				if curI == lastI {
+					return handler(currentSrv, currentStream)
 				}
+				curI++
+				return interceptors[curI](currentSrv, currentStream, info, chainHandler)
 			}
-			chain := handler
-			for i := len(interceptors) - 1; i >= 0; i-- {
-				chain = buildChain(interceptors[i], chain)
-			}
-			return chain(srv, stream)
+
+			return interceptors[0](srv, stream, info, chainHandler)
 		}
+	}
+
+	if n == 1 {
+		return interceptors[0]
+	}
+
+	// n == 0; Dummy interceptor maintained for backward compatibility to avoid returning nil.
+	return func(srv interface{}, stream grpc.ServerStream, _ *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		return handler(srv, stream)
 	}
 }
 
@@ -75,27 +91,35 @@ func ChainStreamServer(interceptors ...grpc.StreamServerInterceptor) grpc.Stream
 // Execution is done in left-to-right order, including passing of context.
 // For example ChainUnaryClient(one, two, three) will execute one before two before three.
 func ChainUnaryClient(interceptors ...grpc.UnaryClientInterceptor) grpc.UnaryClientInterceptor {
-	switch len(interceptors) {
-	case 0:
-		// do not want to return nil interceptor since this function was never defined to do so/for backwards compatibility
+	n := len(interceptors)
+
+	if n > 1 {
+		lastI := n - 1
 		return func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
-			return invoker(ctx, method, req, reply, cc, opts...)
-		}
-	case 1:
-		return interceptors[0]
-	default:
-		return func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
-			buildChain := func(current grpc.UnaryClientInterceptor, next grpc.UnaryInvoker) grpc.UnaryInvoker {
-				return func(currentCtx context.Context, currentMethod string, currentReq, currentRepl interface{}, currentConn *grpc.ClientConn, currentOpts ...grpc.CallOption) error {
-					return current(currentCtx, currentMethod, currentReq, currentRepl, currentConn, next, currentOpts...)
+			var (
+				chainHandler grpc.UnaryInvoker
+				curI         int
+			)
+
+			chainHandler = func(currentCtx context.Context, currentMethod string, currentReq, currentRepl interface{}, currentConn *grpc.ClientConn, currentOpts ...grpc.CallOption) error {
+				if curI == lastI {
+					return invoker(currentCtx, currentMethod, currentReq, currentRepl, currentConn, currentOpts...)
 				}
+				curI++
+				return interceptors[curI](currentCtx, currentMethod, currentReq, currentRepl, currentConn, chainHandler, currentOpts...)
 			}
-			chain := invoker
-			for i := len(interceptors) - 1; i >= 0; i-- {
-				chain = buildChain(interceptors[i], chain)
-			}
-			return chain(ctx, method, req, reply, cc, opts...)
+
+			return interceptors[0](ctx, method, req, reply, cc, chainHandler, opts...)
 		}
+	}
+
+	if n == 1 {
+		return interceptors[0]
+	}
+
+	// n == 0; Dummy interceptor maintained for backward compatibility to avoid returning nil.
+	return func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+		return invoker(ctx, method, req, reply, cc, opts...)
 	}
 }
 
@@ -104,27 +128,35 @@ func ChainUnaryClient(interceptors ...grpc.UnaryClientInterceptor) grpc.UnaryCli
 // Execution is done in left-to-right order, including passing of context.
 // For example ChainStreamClient(one, two, three) will execute one before two before three.
 func ChainStreamClient(interceptors ...grpc.StreamClientInterceptor) grpc.StreamClientInterceptor {
-	switch len(interceptors) {
-	case 0:
-		// do not want to return nil interceptor since this function was never defined to do so/for backwards compatibility
+	n := len(interceptors)
+
+	if n > 1 {
+		lastI := n - 1
 		return func(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string, streamer grpc.Streamer, opts ...grpc.CallOption) (grpc.ClientStream, error) {
-			return streamer(ctx, desc, cc, method, opts...)
-		}
-	case 1:
-		return interceptors[0]
-	default:
-		return func(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string, streamer grpc.Streamer, opts ...grpc.CallOption) (grpc.ClientStream, error) {
-			buildChain := func(current grpc.StreamClientInterceptor, next grpc.Streamer) grpc.Streamer {
-				return func(currentCtx context.Context, currentDesc *grpc.StreamDesc, currentConn *grpc.ClientConn, currentMethod string, currentOpts ...grpc.CallOption) (grpc.ClientStream, error) {
-					return current(currentCtx, currentDesc, currentConn, currentMethod, next, currentOpts...)
+			var (
+				chainHandler grpc.Streamer
+				curI         int
+			)
+
+			chainHandler = func(currentCtx context.Context, currentDesc *grpc.StreamDesc, currentConn *grpc.ClientConn, currentMethod string, currentOpts ...grpc.CallOption) (grpc.ClientStream, error) {
+				if curI == lastI {
+					return streamer(currentCtx, currentDesc, currentConn, currentMethod, currentOpts...)
 				}
+				curI++
+				return interceptors[curI](currentCtx, currentDesc, currentConn, currentMethod, chainHandler, currentOpts...)
 			}
-			chain := streamer
-			for i := len(interceptors) - 1; i >= 0; i-- {
-				chain = buildChain(interceptors[i], chain)
-			}
-			return chain(ctx, desc, cc, method, opts...)
+
+			return interceptors[0](ctx, desc, cc, method, chainHandler, opts...)
 		}
+	}
+
+	if n == 1 {
+		return interceptors[0]
+	}
+
+	// n == 0; Dummy interceptor maintained for backward compatibility to avoid returning nil.
+	return func(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string, streamer grpc.Streamer, opts ...grpc.CallOption) (grpc.ClientStream, error) {
+		return streamer(ctx, desc, cc, method, opts...)
 	}
 }
 


### PR DESCRIPTION
As suggested in #74, along with the requested bench comparison, where:
- 'Master' is upstream master, 'Dev' is the proposed PR;
- 1, 3, 10 is the number of interceptors in the chain;
```
BenchmarkChainUnaryServerCallMaster1-8          300000000              5.65 ns/op            0 B/op          0 allocs/op
BenchmarkChainUnaryServerCallMaster3-8          10000000               197 ns/op             112 B/op        4 allocs/op
BenchmarkChainUnaryServerCallMaster10-8         3000000                560 ns/op             336 B/op        11 allocs/op
BenchmarkChainUnaryServerCallDev1-8             300000000              5.66 ns/op            0 B/op          0 allocs/op
BenchmarkChainUnaryServerCallDev3-8             20000000               116 ns/op             96 B/op         3 allocs/op
BenchmarkChainUnaryServerCallDev10-8            10000000               185 ns/op             96 B/op         3 allocs/op
```

Benchmark code for reference: https://gist.github.com/alcore/8b4aaec19fbdf791b5a4d2630346a75a
I didn't repeat it for the remaining builders since they follow the exact same flow, so the results should be analogous.

The difference is less than I expected initially. Even so, faster is an enemy of fast in the hot path ;-)