### PR TITLE
Add function AddFields that allows setting zap fields without using tags.

### DIFF
--- a/logging/logrus/context.go
+++ b/logging/logrus/context.go
@@ -4,31 +4,63 @@
 package grpc_logrus
 
 import (
-	"github.com/sirupsen/logrus"
 	"github.com/grpc-ecosystem/go-grpc-middleware/tags"
+	"github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
 )
 
 type ctxMarker struct{}
 
+type ctxLogger struct {
+	logger *logrus.Entry
+	fields logrus.Fields
+}
+
 var (
 	ctxMarkerKey = &ctxMarker{}
 )
+
+// AddFields adds logrus fields to the logger.
+func AddFields(ctx context.Context, fields logrus.Fields) {
+	l, ok := ctx.Value(ctxMarkerKey).(*ctxLogger)
+	if !ok || l == nil {
+		return
+	}
+	for k, v := range fields {
+		l.fields[k] = v
+	}
+}
 
 // Extract takes the call-scoped logrus.Entry from grpc_logrus middleware.
 //
 // If the grpc_logrus middleware wasn't used, a no-op `logrus.Entry` is returned. This makes it safe to
 // use regardless.
 func Extract(ctx context.Context) *logrus.Entry {
-	l, ok := ctx.Value(ctxMarkerKey).(*logrus.Entry)
-	if !ok {
+	l, ok := ctx.Value(ctxMarkerKey).(*ctxLogger)
+	if !ok || l == nil {
 		return logrus.NewEntry(nullLogger)
 	}
+
+	fields := logrus.Fields{}
+
 	// Add grpc_ctxtags tags metadata until now.
-	return l.WithFields(logrus.Fields(grpc_ctxtags.Extract(ctx).Values()))
+	tags := grpc_ctxtags.Extract(ctx)
+	for k, v := range tags.Values() {
+		fields[k] = v
+	}
+
+	// Add logrus fields added until now.
+	for k, v := range l.fields {
+		fields[k] = v
+	}
+
+	return l.logger.WithFields(fields)
 }
 
 func toContext(ctx context.Context, entry *logrus.Entry) context.Context {
-	return context.WithValue(ctx, ctxMarkerKey, entry)
-
+	l := &ctxLogger{
+		logger: entry,
+		fields: logrus.Fields{},
+	}
+	return context.WithValue(ctx, ctxMarkerKey, l)
 }

--- a/logging/logrus/server_interceptors_test.go
+++ b/logging/logrus/server_interceptors_test.go
@@ -16,11 +16,11 @@ import (
 
 	"strings"
 
-	"github.com/sirupsen/logrus"
 	"github.com/grpc-ecosystem/go-grpc-middleware"
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/logrus"
 	"github.com/grpc-ecosystem/go-grpc-middleware/tags"
 	pb_testproto "github.com/grpc-ecosystem/go-grpc-middleware/testing/testproto"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
@@ -61,6 +61,7 @@ func (s *logrusServerSuite) TestPing_WithCustomTags() {
 		assert.Contains(s.T(), m, `"grpc.method": "Ping"`, "all lines must contain method name")
 		assert.Contains(s.T(), m, `"custom_tags.string": "something"`, "all lines must contain `custom_tags.string` set by AddFields")
 		assert.Contains(s.T(), m, `"custom_tags.int": 1337`, "all lines must contain `custom_tags.int` set by AddFields")
+		assert.Contains(s.T(), m, `"custom_field": "custom_value"`, "all lines must contain `custom_field` set by AddFields")
 		assert.Contains(s.T(), m, `"span.kind": "server"`, "all lines must contain the kind of call (server)")
 		// request field extraction
 		assert.Contains(s.T(), m, `"grpc.request.value": "something"`, "all lines must contain fields extracted from goodPing because of test.manual_extractfields.pb")

--- a/logging/logrus/shared_test.go
+++ b/logging/logrus/shared_test.go
@@ -7,11 +7,11 @@ import (
 
 	"testing"
 
-	"github.com/sirupsen/logrus"
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/logrus"
 	"github.com/grpc-ecosystem/go-grpc-middleware/tags"
 	"github.com/grpc-ecosystem/go-grpc-middleware/testing"
 	pb_testproto "github.com/grpc-ecosystem/go-grpc-middleware/testing/testproto"
+	"github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
 )
@@ -35,6 +35,7 @@ func customCodeToLevel(c codes.Code) logrus.Level {
 
 func (s *loggingPingService) Ping(ctx context.Context, ping *pb_testproto.PingRequest) (*pb_testproto.PingResponse, error) {
 	grpc_ctxtags.Extract(ctx).Set("custom_tags.string", "something").Set("custom_tags.int", 1337)
+	grpc_logrus.AddFields(ctx, logrus.Fields{"custom_field": "custom_value"})
 	grpc_logrus.Extract(ctx).Info("some ping")
 	return s.TestServiceServer.Ping(ctx, ping)
 }
@@ -45,6 +46,7 @@ func (s *loggingPingService) PingError(ctx context.Context, ping *pb_testproto.P
 
 func (s *loggingPingService) PingList(ping *pb_testproto.PingRequest, stream pb_testproto.TestService_PingListServer) error {
 	grpc_ctxtags.Extract(stream.Context()).Set("custom_tags.string", "something").Set("custom_tags.int", 1337)
+	grpc_logrus.AddFields(stream.Context(), logrus.Fields{"custom_field": "custom_value"})
 	grpc_logrus.Extract(stream.Context()).Info("some pinglist")
 	return s.TestServiceServer.PingList(ping, stream)
 }

--- a/logging/zap/context.go
+++ b/logging/zap/context.go
@@ -12,21 +12,38 @@ import (
 
 type ctxMarker struct{}
 
+type ctxLogger struct {
+	logger *zap.Logger
+	fields []zapcore.Field
+}
+
 var (
 	ctxMarkerKey = &ctxMarker{}
 	nullLogger   = zap.NewNop()
 )
 
+// AddFields adds zap fields to the logger.
+func AddFields(ctx context.Context, fields ...zapcore.Field) {
+	l, ok := ctx.Value(ctxMarkerKey).(*ctxLogger)
+	if !ok || l == nil {
+		return
+	}
+	l.fields = append(l.fields, fields...)
+}
+
 // Extract takes the call-scoped Logger from grpc_zap middleware.
 //
 // It always returns a Logger that has all the grpc_ctxtags updated.
 func Extract(ctx context.Context) *zap.Logger {
-	l, ok := ctx.Value(ctxMarkerKey).(*zap.Logger)
-	if !ok {
+	l, ok := ctx.Value(ctxMarkerKey).(*ctxLogger)
+	if !ok || l == nil {
 		return nullLogger
 	}
 	// Add grpc_ctxtags tags metadata until now.
-	return l.With(tagsFieldsToZapFields(ctx)...)
+	fields := tagsFieldsToZapFields(ctx)
+	// Add zap fields added until now.
+	fields = append(fields, l.fields...)
+	return l.logger.With(fields...)
 }
 
 func tagsFieldsToZapFields(ctx context.Context) []zapcore.Field {
@@ -39,5 +56,8 @@ func tagsFieldsToZapFields(ctx context.Context) []zapcore.Field {
 }
 
 func toContext(ctx context.Context, logger *zap.Logger) context.Context {
-	return context.WithValue(ctx, ctxMarkerKey, logger)
+	l := &ctxLogger{
+		logger: logger,
+	}
+	return context.WithValue(ctx, ctxMarkerKey, l)
 }

--- a/logging/zap/server_interceptors_test.go
+++ b/logging/zap/server_interceptors_test.go
@@ -67,6 +67,7 @@ func (s *zapServerSuite) TestPing_WithCustomTags() {
 		assert.Contains(s.T(), m, `grpc.method": "Ping"`, "all lines must contain method name")
 		assert.Contains(s.T(), m, `"custom_tags.string": "something"`, "all lines must contain `custom_tags.string` set by AddFields")
 		assert.Contains(s.T(), m, `"custom_tags.int": 1337`, "all lines must contain `custom_tags.int` set by AddFields")
+		assert.Contains(s.T(), m, `"custom_field": "custom_value"`, "all lines must contain `custom_field` set by AddFields")
 		// request field extraction
 		assert.Contains(s.T(), m, `"grpc.request.value": "something"`, "all lines must contain fields extracted from goodPing because of test.manual_extractfields.pb")
 	}

--- a/logging/zap/shared_test.go
+++ b/logging/zap/shared_test.go
@@ -25,6 +25,7 @@ type loggingPingService struct {
 
 func (s *loggingPingService) Ping(ctx context.Context, ping *pb_testproto.PingRequest) (*pb_testproto.PingResponse, error) {
 	grpc_ctxtags.Extract(ctx).Set("custom_tags.string", "something").Set("custom_tags.int", 1337)
+	grpc_zap.AddFields(ctx, zap.String("custom_field", "custom_value"))
 	grpc_zap.Extract(ctx).Info("some ping")
 	return s.TestServiceServer.Ping(ctx, ping)
 }


### PR DESCRIPTION
This allows setting zap fields on the logger that persist. zap.fields ensure type safety on the fields.