### PR TITLE
Support retrying gRPCs with chained interceptors

### DIFF
--- a/DOC.md
+++ b/DOC.md
@@ -42,6 +42,8 @@ Here's an example for client side chaining:
 
 These interceptors will be executed from left to right: monitoring and then retry logic.
 
+The retry interceptor will call every interceptor that follows it whenever when a retry happens.
+
 ### Writing Your Own
 Implementing your own interceptor is pretty trivial: there are interfaces for that. But the interesting
 bit exposing common data to handlers (and other middleware), similarly to HTTP Middleware design.
@@ -84,7 +86,7 @@ needed. For example:
 #### <a name="pkg-files">Package files</a>
 [chain.go](./chain.go) [doc.go](./doc.go) [wrappers.go](./wrappers.go) 
 
-## <a name="ChainStreamClient">func</a> [ChainStreamClient](./chain.go#L130)
+## <a name="ChainStreamClient">func</a> [ChainStreamClient](./chain.go#L136)
 ``` go
 func ChainStreamClient(interceptors ...grpc.StreamClientInterceptor) grpc.StreamClientInterceptor
 ```
@@ -93,7 +95,7 @@ ChainStreamClient creates a single interceptor out of a chain of many intercepto
 Execution is done in left-to-right order, including passing of context.
 For example ChainStreamClient(one, two, three) will execute one before two before three.
 
-## <a name="ChainStreamServer">func</a> [ChainStreamServer](./chain.go#L56)
+## <a name="ChainStreamServer">func</a> [ChainStreamServer](./chain.go#L58)
 ``` go
 func ChainStreamServer(interceptors ...grpc.StreamServerInterceptor) grpc.StreamServerInterceptor
 ```
@@ -103,7 +105,7 @@ Execution is done in left-to-right order, including passing of context.
 For example ChainUnaryServer(one, two, three) will execute one before two before three.
 If you want to pass context between interceptors, use WrapServerStream.
 
-## <a name="ChainUnaryClient">func</a> [ChainUnaryClient](./chain.go#L93)
+## <a name="ChainUnaryClient">func</a> [ChainUnaryClient](./chain.go#L97)
 ``` go
 func ChainUnaryClient(interceptors ...grpc.UnaryClientInterceptor) grpc.UnaryClientInterceptor
 ```
@@ -122,14 +124,14 @@ Execution is done in left-to-right order, including passing of context.
 For example ChainUnaryServer(one, two, three) will execute one before two before three, and three
 will see context changes of one and two.
 
-## <a name="WithStreamServerChain">func</a> [WithStreamServerChain](./chain.go#L173)
+## <a name="WithStreamServerChain">func</a> [WithStreamServerChain](./chain.go#L181)
 ``` go
 func WithStreamServerChain(interceptors ...grpc.StreamServerInterceptor) grpc.ServerOption
 ```
 WithStreamServerChain is a grpc.Server config option that accepts multiple stream interceptors.
 Basically syntactic sugar.
 
-## <a name="WithUnaryServerChain">func</a> [WithUnaryServerChain](./chain.go#L167)
+## <a name="WithUnaryServerChain">func</a> [WithUnaryServerChain](./chain.go#L175)
 ``` go
 func WithUnaryServerChain(interceptors ...grpc.UnaryServerInterceptor) grpc.ServerOption
 ```

--- a/chain.go
+++ b/chain.go
@@ -31,7 +31,9 @@ func ChainUnaryServer(interceptors ...grpc.UnaryServerInterceptor) grpc.UnarySer
 					return handler(currentCtx, currentReq)
 				}
 				curI++
-				return interceptors[curI](currentCtx, currentReq, info, chainHandler)
+				resp, err := interceptors[curI](currentCtx, currentReq, info, chainHandler)
+				curI--
+				return resp, err
 			}
 
 			return interceptors[0](ctx, req, info, chainHandler)
@@ -69,7 +71,9 @@ func ChainStreamServer(interceptors ...grpc.StreamServerInterceptor) grpc.Stream
 					return handler(currentSrv, currentStream)
 				}
 				curI++
-				return interceptors[curI](currentSrv, currentStream, info, chainHandler)
+				err := interceptors[curI](currentSrv, currentStream, info, chainHandler)
+				curI--
+				return err
 			}
 
 			return interceptors[0](srv, stream, info, chainHandler)
@@ -106,7 +110,9 @@ func ChainUnaryClient(interceptors ...grpc.UnaryClientInterceptor) grpc.UnaryCli
 					return invoker(currentCtx, currentMethod, currentReq, currentRepl, currentConn, currentOpts...)
 				}
 				curI++
-				return interceptors[curI](currentCtx, currentMethod, currentReq, currentRepl, currentConn, chainHandler, currentOpts...)
+				err := interceptors[curI](currentCtx, currentMethod, currentReq, currentRepl, currentConn, chainHandler, currentOpts...)
+				curI--
+				return err
 			}
 
 			return interceptors[0](ctx, method, req, reply, cc, chainHandler, opts...)
@@ -143,7 +149,9 @@ func ChainStreamClient(interceptors ...grpc.StreamClientInterceptor) grpc.Stream
 					return streamer(currentCtx, currentDesc, currentConn, currentMethod, currentOpts...)
 				}
 				curI++
-				return interceptors[curI](currentCtx, currentDesc, currentConn, currentMethod, chainHandler, currentOpts...)
+				stream, err := interceptors[curI](currentCtx, currentDesc, currentConn, currentMethod, chainHandler, currentOpts...)
+				curI--
+				return stream, err
 			}
 
 			return interceptors[0](ctx, desc, cc, method, chainHandler, opts...)

--- a/doc.go
+++ b/doc.go
@@ -40,6 +40,8 @@ Here's an example for client side chaining:
 
 These interceptors will be executed from left to right: monitoring and then retry logic.
 
+The retry interceptor will call every interceptor that follows it whenever when a retry happens.
+
 Writing Your Own
 
 Implementing your own interceptor is pretty trivial: there are interfaces for that. But the interesting

--- a/retry/DOC.md
+++ b/retry/DOC.md
@@ -20,6 +20,9 @@ override the number of retries (setting them to more than 0) with a `grpc.Client
 Other default options are: retry on `ResourceExhausted` and `Unavailable` gRPC codes, use a 50ms
 linear backoff with 10% jitter.
 
+For chained interceptors, the retry interceptor will call every interceptor that follows it
+whenever when a retry happens.
+
 Please see examples for more advanced use.
 
 ## <a name="pkg-imports">Imported Packages</a>

--- a/retry/doc.go
+++ b/retry/doc.go
@@ -17,6 +17,9 @@ override the number of retries (setting them to more than 0) with a `grpc.Client
 Other default options are: retry on `ResourceExhausted` and `Unavailable` gRPC codes, use a 50ms
 linear backoff with 10% jitter.
 
+For chained interceptors, the retry interceptor will call every interceptor that follows it
+whenever when a retry happens.
+
 Please see examples for more advanced use.
 */
 package grpc_retry

--- a/retry/retry_test.go
+++ b/retry/retry_test.go
@@ -11,6 +11,7 @@ import (
 
 	pb_testproto "github.com/grpc-ecosystem/go-grpc-middleware/testing/testproto"
 
+	"github.com/grpc-ecosystem/go-grpc-middleware"
 	"github.com/grpc-ecosystem/go-grpc-middleware/retry"
 	"github.com/grpc-ecosystem/go-grpc-middleware/testing"
 
@@ -254,4 +255,90 @@ func (s *RetrySuite) assertPingListWasCorrect(stream pb_testproto.TestService_Pi
 		count += 1
 	}
 	require.EqualValues(s.T(), grpc_testing.ListResponseCount, count, "should have received all ping items")
+}
+
+type trackedInterceptor struct {
+	called int
+}
+
+func (ti *trackedInterceptor) UnaryClientInterceptor(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+	ti.called++
+	return invoker(ctx, method, req, reply, cc, opts...)
+}
+
+func (ti *trackedInterceptor) StreamClientInterceptor(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string, streamer grpc.Streamer, opts ...grpc.CallOption) (grpc.ClientStream, error) {
+	ti.called++
+	return streamer(ctx, desc, cc, method, opts...)
+}
+
+func TestChainedRetrySuite(t *testing.T) {
+	service := &failingService{
+		TestServiceServer: &grpc_testing.TestPingService{T: t},
+	}
+	preRetryInterceptor := &trackedInterceptor{}
+	postRetryInterceptor := &trackedInterceptor{}
+	s := &ChainedRetrySuite{
+		srv: service,
+		preRetryInterceptor: preRetryInterceptor,
+		postRetryInterceptor: postRetryInterceptor,
+		InterceptorTestSuite: &grpc_testing.InterceptorTestSuite{
+			TestService: service,
+			ClientOpts: []grpc.DialOption{
+				grpc.WithUnaryInterceptor(grpc_middleware.ChainUnaryClient(preRetryInterceptor.UnaryClientInterceptor, grpc_retry.UnaryClientInterceptor(), postRetryInterceptor.UnaryClientInterceptor)),
+				grpc.WithStreamInterceptor(grpc_middleware.ChainStreamClient(preRetryInterceptor.StreamClientInterceptor, grpc_retry.StreamClientInterceptor(), postRetryInterceptor.StreamClientInterceptor)),
+			},
+		},
+	}
+	suite.Run(t, s)
+}
+
+type ChainedRetrySuite struct {
+	*grpc_testing.InterceptorTestSuite
+	srv *failingService
+	preRetryInterceptor *trackedInterceptor
+	postRetryInterceptor *trackedInterceptor
+}
+
+func (s *ChainedRetrySuite) SetupTest() {
+	s.srv.resetFailingConfiguration( /* don't fail */ 0, codes.OK, noSleep)
+	s.preRetryInterceptor.called = 0
+	s.postRetryInterceptor.called = 0
+}
+
+func (s *ChainedRetrySuite) TestUnaryWithChainedInterceptors_NoFailure() {
+	_, err := s.Client.Ping(s.SimpleCtx(), goodPing, grpc_retry.WithMax(2))
+	require.NoError(s.T(), err, "the invocation should succeed")
+	require.EqualValues(s.T(), 1, s.srv.requestCount(), "one request should have been made")
+	require.EqualValues(s.T(), 1, s.preRetryInterceptor.called, "pre-retry interceptor should be called once")
+	require.EqualValues(s.T(), 1, s.postRetryInterceptor.called, "post-retry interceptor should be called once")
+}
+
+func (s *ChainedRetrySuite) TestUnaryWithChainedInterceptors_WithRetry() {
+	s.srv.resetFailingConfiguration(2, codes.Unavailable, noSleep)
+	_, err := s.Client.Ping(s.SimpleCtx(), goodPing, grpc_retry.WithMax(2))
+	require.NoError(s.T(), err, "the second invocation should succeed")
+	require.EqualValues(s.T(), 2, s.srv.requestCount(), "two requests should have been made")
+	require.EqualValues(s.T(), 1, s.preRetryInterceptor.called, "pre-retry interceptor should be called once")
+	require.EqualValues(s.T(), 2, s.postRetryInterceptor.called, "post-retry interceptor should be called twice")
+}
+
+func (s *ChainedRetrySuite) TestStreamWithChainedInterceptors_NoFailure() {
+	stream, err := s.Client.PingList(s.SimpleCtx(), goodPing, grpc_retry.WithMax(2))
+	require.NoError(s.T(), err, "the invocation should succeed")
+	_, err = stream.Recv()
+	require.NoError(s.T(), err, "the Recv should succeed")
+	require.EqualValues(s.T(), 1, s.srv.requestCount(), "one request should have been made")
+	require.EqualValues(s.T(), 1, s.preRetryInterceptor.called, "pre-retry interceptor should be called once")
+	require.EqualValues(s.T(), 1, s.postRetryInterceptor.called, "post-retry interceptor should be called once")
+}
+
+func (s *ChainedRetrySuite) TestStreamWithChainedInterceptors_WithRetry() {
+	s.srv.resetFailingConfiguration(2, codes.Unavailable, noSleep)
+	stream, err := s.Client.PingList(s.SimpleCtx(), goodPing, grpc_retry.WithMax(2))
+	require.NoError(s.T(), err, "the second invocation should succeed")
+	_, err = stream.Recv()
+	require.NoError(s.T(), err, "the Recv should succeed")
+	require.EqualValues(s.T(), 2, s.srv.requestCount(), "two requests should have been made")
+	require.EqualValues(s.T(), 1, s.preRetryInterceptor.called, "pre-retry interceptor should be called once")
+	require.EqualValues(s.T(), 2, s.postRetryInterceptor.called, "post-retry interceptor should be called twice")
 }

--- a/retry/retry_test.go
+++ b/retry/retry_test.go
@@ -278,8 +278,8 @@ func TestChainedRetrySuite(t *testing.T) {
 	preRetryInterceptor := &trackedInterceptor{}
 	postRetryInterceptor := &trackedInterceptor{}
 	s := &ChainedRetrySuite{
-		srv: service,
-		preRetryInterceptor: preRetryInterceptor,
+		srv:                  service,
+		preRetryInterceptor:  preRetryInterceptor,
 		postRetryInterceptor: postRetryInterceptor,
 		InterceptorTestSuite: &grpc_testing.InterceptorTestSuite{
 			TestService: service,
@@ -294,8 +294,8 @@ func TestChainedRetrySuite(t *testing.T) {
 
 type ChainedRetrySuite struct {
 	*grpc_testing.InterceptorTestSuite
-	srv *failingService
-	preRetryInterceptor *trackedInterceptor
+	srv                  *failingService
+	preRetryInterceptor  *trackedInterceptor
 	postRetryInterceptor *trackedInterceptor
 }
 


### PR DESCRIPTION
As retries may cause a handler chain to be partially re-executed the
interceptor needs to be reset as the recursion unrolls.

Fix for #110 

Possibly regressed as part of 
https://github.com/grpc-ecosystem/go-grpc-middleware/commit/5d4723c22d97b439cd03632da61f4cfc6e94f8bb

Added tests to the retry_test as this case seemed retry specific, but did feel odd to test the chaining in the retry.