### PR TITLE
update docs to advise to only Extract once

### DIFF
--- a/logging/logrus/doc.go
+++ b/logging/logrus/doc.go
@@ -10,6 +10,9 @@ It accepts a user-configured `logrus.Entry` that will be used for logging comple
 You can use `Extract` to log into a request-scoped `logrus.Entry` instance in your handler code. The fields set on the
 logger correspond to the grpc_ctxtags.Tags attached to the context.
 
+As `Extract` will iterate all tags on from `grpc_ctxtags` it is therefore expensive so it is advised that you 
+extract once at the start of the function from the context and reuse it for the remainder of the function (see examples).
+
 This package also implements request and response *payload* logging, both for server-side and client-side. These will be
 logged as structured `jsonbp` fields for every message received/sent (both unary and streaming). For that please use
 `Payload*Interceptor` functions for that. Please note that the user-provided function that determines whetether to log

--- a/logging/logrus/examples_test.go
+++ b/logging/logrus/examples_test.go
@@ -67,8 +67,10 @@ func Example_handlerUsageUnaryPing() interface{} {
 	x := func(ctx context.Context, ping *pb_testproto.PingRequest) (*pb_testproto.PingResponse, error) {
 		// Add fields the ctxtags of the request which will be added to all extracted loggers.
 		grpc_ctxtags.Extract(ctx).Set("custom_tags.string", "something").Set("custom_tags.int", 1337)
-		// Extract a request-scoped zap.Logger and log a message.
-		grpc_logrus.Extract(ctx).Info("some ping")
+		// Extract a single request-scoped logrus.Logger and log messages.
+		l := grpc_logrus.Extract(ctx)
+		l.Info("some ping")
+		l.Info("another ping")
 		return &pb_testproto.PingResponse{Value: ping.Value}, nil
 	}
 	return x

--- a/logging/zap/doc.go
+++ b/logging/zap/doc.go
@@ -10,6 +10,9 @@ be used for logging completed gRPC calls, and be populated into the `context.Con
 You can use `Extract` to log into a request-scoped `zap.Logger` instance in your handler code. The fields set on the
 logger correspond to the grpc_ctxtags.Tags attached to the context.
 
+As `Extract` will iterate all tags on from `grpc_ctxtags` it is therefore expensive so it is advised that you 
+extract once at the start of the function from the context and reuse it for the remainder of the function (see examples).
+
 This package also implements request and response *payload* logging, both for server-side and client-side. These will be
 logged as structured `jsonbp` fields for every message received/sent (both unary and streaming). For that please use
 `Payload*Interceptor` functions for that. Please note that the user-provided function that determines whetether to log

--- a/logging/zap/examples_test.go
+++ b/logging/zap/examples_test.go
@@ -66,8 +66,10 @@ func Example_handlerUsageUnaryPing() interface{} {
 	x := func(ctx context.Context, ping *pb_testproto.PingRequest) (*pb_testproto.PingResponse, error) {
 		// Add fields the ctxtags of the request which will be added to all extracted loggers.
 		grpc_ctxtags.Extract(ctx).Set("custom_tags.string", "something").Set("custom_tags.int", 1337)
-		// Extract a request-scoped zap.Logger and log a message.
-		grpc_zap.Extract(ctx).Info("some ping")
+		// Extract a single request-scoped zap.Logger and log messages.
+		l := grpc_zap.Extract(ctx)
+		l.Info("some ping")
+		l.Info("another ping")
 		return &pb_testproto.PingResponse{Value: ping.Value}, nil
 	}
 	return x


### PR DESCRIPTION
updating documentation to show that it is more efficient to only call Extract once in a method.