### PR TITLE
Fix #116 - sub millisecond duration should now be measured by default

### DIFF
--- a/logging/logrus/options.go
+++ b/logging/logrus/options.go
@@ -181,5 +181,5 @@ func DurationToDurationField(duration time.Duration) (key string, value interfac
 }
 
 func durationToMilliseconds(duration time.Duration) float32 {
-	return float32(duration.Nanoseconds() / 1000 / 1000)
+	return float32(duration.Nanoseconds()) / 1000 / 1000
 }

--- a/logging/logrus/options.go
+++ b/logging/logrus/options.go
@@ -181,5 +181,5 @@ func DurationToDurationField(duration time.Duration) (key string, value interfac
 }
 
 func durationToMilliseconds(duration time.Duration) float32 {
-	return float32(duration.Nanoseconds()) / 1000 / 1000
+	return float32(duration.Nanoseconds()/1000) / 1000
 }

--- a/logging/logrus/options_test.go
+++ b/logging/logrus/options_test.go
@@ -8,5 +8,5 @@ import (
 
 func TestDurationToTimeMillisField(t *testing.T) {
 	_, val := DurationToTimeMillisField(time.Microsecond * 100)
-	assert.Equal(t, val.(float32), float32(0.1),  "sub millisecond value should be return more precise")
+	assert.Equal(t, val.(float32), float32(0.1),  "sub millisecond values should be correct")
 }

--- a/logging/logrus/options_test.go
+++ b/logging/logrus/options_test.go
@@ -8,5 +8,5 @@ import (
 
 func TestDurationToTimeMillisField(t *testing.T) {
 	_, val := DurationToTimeMillisField(time.Microsecond * 100)
-	assert.Equal(t, val.(float32), float32(0.1),  "sub millisecond values should be correct")
+	assert.Equal(t, val.(float32), float32(0.1), "sub millisecond values should be correct")
 }

--- a/logging/logrus/options_test.go
+++ b/logging/logrus/options_test.go
@@ -1,0 +1,12 @@
+package grpc_logrus
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
+)
+
+func TestDurationToTimeMillisField(t *testing.T) {
+	_, val := DurationToTimeMillisField(time.Microsecond * 100)
+	assert.Equal(t, val.(float32), float32(0.1),  "sub millisecond value should be return more precise")
+}

--- a/logging/logrus/server_interceptors.go
+++ b/logging/logrus/server_interceptors.go
@@ -33,7 +33,7 @@ func UnaryServerInterceptor(entry *logrus.Entry, opts ...Option) grpc.UnaryServe
 		}
 		code := o.codeFunc(err)
 		level := o.levelFunc(code)
-		durField, durVal := o.durationFunc(time.Now().Sub(startTime))
+		durField, durVal := o.durationFunc(time.Since(startTime))
 		fields := logrus.Fields{
 			"grpc.code": code.String(),
 			durField:    durVal,
@@ -67,7 +67,7 @@ func StreamServerInterceptor(entry *logrus.Entry, opts ...Option) grpc.StreamSer
 		}
 		code := o.codeFunc(err)
 		level := o.levelFunc(code)
-		durField, durVal := o.durationFunc(time.Now().Sub(startTime))
+		durField, durVal := o.durationFunc(time.Since(startTime))
 		fields := logrus.Fields{
 			"grpc.code": code.String(),
 			durField:    durVal,

--- a/logging/zap/DOC.md
+++ b/logging/zap/DOC.md
@@ -228,7 +228,7 @@ func StreamClientInterceptor(logger *zap.Logger, opts ...Option) grpc.StreamClie
 ```
 StreamServerInterceptor returns a new streaming client interceptor that optionally logs the execution of external gRPC calls.
 
-## <a name="StreamServerInterceptor">func</a> [StreamServerInterceptor](./server_interceptors.go#L48)
+## <a name="StreamServerInterceptor">func</a> [StreamServerInterceptor](./server_interceptors.go#L50)
 ``` go
 func StreamServerInterceptor(logger *zap.Logger, opts ...Option) grpc.StreamServerInterceptor
 ```

--- a/logging/zap/DOC.md
+++ b/logging/zap/DOC.md
@@ -228,7 +228,7 @@ func StreamClientInterceptor(logger *zap.Logger, opts ...Option) grpc.StreamClie
 ```
 StreamServerInterceptor returns a new streaming client interceptor that optionally logs the execution of external gRPC calls.
 
-## <a name="StreamServerInterceptor">func</a> [StreamServerInterceptor](./server_interceptors.go#L50)
+## <a name="StreamServerInterceptor">func</a> [StreamServerInterceptor](./server_interceptors.go#L48)
 ``` go
 func StreamServerInterceptor(logger *zap.Logger, opts ...Option) grpc.StreamServerInterceptor
 ```

--- a/logging/zap/options.go
+++ b/logging/zap/options.go
@@ -180,5 +180,5 @@ func DurationToDurationField(duration time.Duration) zapcore.Field {
 }
 
 func durationToMilliseconds(duration time.Duration) float32 {
-	return float32(duration.Nanoseconds() / 1000 / 1000)
+	return float32(duration.Nanoseconds()) / 1000 / 1000
 }

--- a/logging/zap/options.go
+++ b/logging/zap/options.go
@@ -180,5 +180,5 @@ func DurationToDurationField(duration time.Duration) zapcore.Field {
 }
 
 func durationToMilliseconds(duration time.Duration) float32 {
-	return float32(duration.Nanoseconds()) / 1000 / 1000
+	return float32(duration.Nanoseconds()/1000) / 1000
 }

--- a/logging/zap/options_test.go
+++ b/logging/zap/options_test.go
@@ -1,0 +1,15 @@
+package grpc_zap
+
+import (
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap/zapcore"
+	"math"
+	"testing"
+	"time"
+)
+
+func TestDurationToTimeMillisField(t *testing.T) {
+	val := DurationToTimeMillisField(time.Microsecond * 100)
+	assert.Equal(t, val.Type, zapcore.Float32Type, "should be a float type")
+	assert.Equal(t, math.Float32frombits(uint32(val.Integer)), float32(0.1), "should be bigger than 0")
+}

--- a/logging/zap/options_test.go
+++ b/logging/zap/options_test.go
@@ -11,5 +11,5 @@ import (
 func TestDurationToTimeMillisField(t *testing.T) {
 	val := DurationToTimeMillisField(time.Microsecond * 100)
 	assert.Equal(t, val.Type, zapcore.Float32Type, "should be a float type")
-	assert.Equal(t, math.Float32frombits(uint32(val.Integer)), float32(0.1), "should be bigger than 0")
+	assert.Equal(t, math.Float32frombits(uint32(val.Integer)), float32(0.1), "sub millisecond values should be correct")
 }

--- a/logging/zap/server_interceptors.go
+++ b/logging/zap/server_interceptors.go
@@ -39,7 +39,7 @@ func UnaryServerInterceptor(logger *zap.Logger, opts ...Option) grpc.UnaryServer
 		ctx_zap.Extract(newCtx).Check(level, "finished unary call").Write(
 			zap.Error(err),
 			zap.String("grpc.code", code.String()),
-			o.durationFunc(time.Now().Sub(startTime)),
+			o.durationFunc(time.Since(startTime)),
 		)
 
 		return resp, err
@@ -66,7 +66,7 @@ func StreamServerInterceptor(logger *zap.Logger, opts ...Option) grpc.StreamServ
 		ctx_zap.Extract(newCtx).Check(level, "finished streaming call").Write(
 			zap.Error(err),
 			zap.String("grpc.code", code.String()),
-			o.durationFunc(time.Now().Sub(startTime)),
+			o.durationFunc(time.Since(startTime)),
 		)
 
 		return err


### PR DESCRIPTION
Currently issue #116 is raised due to sub ms durations being logged as 0ms we can fix this by casting the duration to a float before we do the division.

This change will mean that if your `grpc.time_ms` is greater than one it will be represented as a whole number of ms `10` otherwise it will be displayed to 3 decimal places `0.542`.