### PR TITLE
WIP: Add MuxUnaryServer routing middleware

### DIFF
--- a/mux.go
+++ b/mux.go
@@ -1,0 +1,23 @@
+// gRPC Server Interceptor routing middleware.
+
+package grpc_middleware
+
+import (
+	"golang.org/x/net/context"
+	"google.golang.org/grpc"
+)
+
+type UnaryMux map[string]grpc.UnaryServerInterceptor
+
+// MuxUnaryServer creates a single interceptor out of a map of RPC to interceptors.
+func MuxUnaryServer(mux UnaryMux) grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+		if i, ok := mux[info.FullMethod]; ok {
+			return i(ctx, req, info, handler)
+		}
+		if i, ok := mux["default"]; ok {
+			return i(ctx, req, info, handler)
+		}
+		return handler(ctx, req)
+	}
+}

--- a/mux_test.go
+++ b/mux_test.go
@@ -9,9 +9,9 @@ import (
 )
 
 var (
-	methodA1  = "serviceA.Method1"
-	methodA2  = "serviceA.Method2"
-	methodB1  = "serviceB.Method1"
+	methodA1 = "serviceA.Method1"
+	methodA2 = "serviceA.Method2"
+	methodB1 = "serviceB.Method1"
 )
 
 func TestMuxUnaryServer(t *testing.T) {
@@ -27,9 +27,9 @@ func TestMuxUnaryServer(t *testing.T) {
 	mux := MuxUnaryServer(UnaryMux{methodA1: first, methodA2: second, "default": third})
 
 	tests := [][]string{
-			{methodA1, "parent/first"},
-		  	{methodA2, "parent/second"},
-			{methodB1, "parent/third"},
+		{methodA1, "parent/first"},
+		{methodA2, "parent/second"},
+		{methodB1, "parent/third"},
 	}
 	for _, tt := range tests {
 		out, _ := mux(context.WithValue(parentContext, "path", "parent"), input, &grpc.UnaryServerInfo{FullMethod: tt[0]}, handler)
@@ -41,9 +41,9 @@ func pathInterceptor(node string) grpc.UnaryServerInterceptor {
 	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
 		path := ctx.Value("path")
 		if str, ok := path.(string); ok {
-			ctx = context.WithValue(ctx, "path", str + "/" + node) 
+			ctx = context.WithValue(ctx, "path", str+"/"+node)
 		} else {
-			ctx = context.WithValue(ctx, "path", "previous path not a string at " + node)
+			ctx = context.WithValue(ctx, "path", "previous path not a string at "+node)
 		}
 		return handler(ctx, req)
 	}

--- a/mux_test.go
+++ b/mux_test.go
@@ -1,0 +1,50 @@
+package grpc_middleware
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/net/context"
+	"google.golang.org/grpc"
+)
+
+var (
+	methodA1  = "serviceA.Method1"
+	methodA2  = "serviceA.Method2"
+	methodB1  = "serviceB.Method1"
+)
+
+func TestMuxUnaryServer(t *testing.T) {
+	input := "input"
+
+	first := pathInterceptor("first")
+	second := pathInterceptor("second")
+	third := pathInterceptor("third")
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return ctx.Value("path"), nil
+	}
+
+	mux := MuxUnaryServer(UnaryMux{methodA1: first, methodA2: second, "default": third})
+
+	tests := [][]string{
+			{methodA1, "parent/first"},
+		  	{methodA2, "parent/second"},
+			{methodB1, "parent/third"},
+	}
+	for _, tt := range tests {
+		out, _ := mux(context.WithValue(parentContext, "path", "parent"), input, &grpc.UnaryServerInfo{FullMethod: tt[0]}, handler)
+		require.EqualValues(t, tt[1], out, "mux path is incorrect")
+	}
+}
+
+func pathInterceptor(node string) grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+		path := ctx.Value("path")
+		if str, ok := path.(string); ok {
+			ctx = context.WithValue(ctx, "path", str + "/" + node) 
+		} else {
+			ctx = context.WithValue(ctx, "path", "previous path not a string at " + node)
+		}
+		return handler(ctx, req)
+	}
+}


### PR DESCRIPTION
Adds a per-RPC routing so you can have different middleware chains for different calls in the same server (for example, some that require auth and some that don't).

Thoughts and opinions?