### PR TITLE
Zap custom jsonpb to allow optional gogo JSONPb serialization

### DIFF
--- a/logging/zap/DOC.md
+++ b/logging/zap/DOC.md
@@ -31,7 +31,7 @@ Below is a JSON formatted example of a log that would be logged by the server in
 	{
 	  "level": "info",									// string  zap log levels
 	  "msg": "finished unary call",						// string  log message
-	
+
 	  "grpc.code": "OK",								// string  grpc status code
 	  "grpc.method": "Ping",							// string  method name
 	  "grpc.service": "mwitkow.testproto.TestService",  // string  full name of the called service
@@ -39,7 +39,7 @@ Below is a JSON formatted example of a log that would be logged by the server in
 	  "grpc.request.deadline": "2006-01-02T15:04:05Z07:00",   // string  RFC3339 deadline of the current request if supplied
 	  "grpc.request.value": "something",				// string  value on the request
 	  "grpc.time_ms": 1.345,							// float32 run time of the call in ms
-	
+
 	  "peer.address": {
 	    "IP": "127.0.0.1",								// string  IP address of calling party
 	    "Port": 60216,									// int     port call is coming in on
@@ -47,7 +47,7 @@ Below is a JSON formatted example of a log that would be logged by the server in
 	  },
 	  "span.kind": "server",							// string  client | server
 	  "system": "grpc"									// string
-	
+
 	  "custom_field": "custom_value",					// string  user defined field
 	  "custom_tags.int": 1337,							// int     user defined tag on the ctx
 	  "custom_tags.string": "something",				// string  user defined tag on the ctx
@@ -59,7 +59,7 @@ Below is a JSON formatted example of a log that would be logged by the payload i
 	{
 	  "level": "info",													// string zap log levels
 	  "msg": "client request payload logged as grpc.request.content",   // string log message
-	
+
 	  "grpc.request.content": {											// object content of RPC request
 	    "msg" : {														// object ZAP specific inner object
 		  "value": "something",											// string defined by caller
@@ -68,7 +68,7 @@ Below is a JSON formatted example of a log that would be logged by the payload i
 	  },
 	  "grpc.method": "Ping",											// string method being called
 	  "grpc.service": "mwitkow.testproto.TestService",					// string service being called
-	
+
 	  "span.kind": "client",											// string client | server
 	  "system": "grpc"													// string
 	}
@@ -207,7 +207,7 @@ _ = grpc.NewServer(
 * [Package (InitializationWithDurationFieldOverride)](#example__initializationWithDurationFieldOverride)
 
 #### <a name="pkg-files">Package files</a>
-[client_interceptors.go](./client_interceptors.go) [context.go](./context.go) [doc.go](./doc.go) [grpclogger.go](./grpclogger.go) [options.go](./options.go) [payload_interceptors.go](./payload_interceptors.go) [server_interceptors.go](./server_interceptors.go) 
+[client_interceptors.go](./client_interceptors.go) [context.go](./context.go) [doc.go](./doc.go) [grpclogger.go](./grpclogger.go) [options.go](./options.go) [payload_interceptors.go](./payload_interceptors.go) [server_interceptors.go](./server_interceptors.go)
 
 ## <a name="pkg-variables">Variables</a>
 ``` go
@@ -232,8 +232,8 @@ DefaultDurationToField is the default implementation of converting request durat
 
 ``` go
 var (
-    // JsonPbMarshaller is the marshaller used for serializing protobuf messages.
-    JsonPbMarshaller = &jsonpb.Marshaler{}
+    // JsonPbMarshaler is the marshaler used for serializing protobuf messages.
+    JsonPbMarshaler Marshaler = &runtime.JSONPb{}
 )
 ```
 

--- a/logging/zap/payload_interceptors.go
+++ b/logging/zap/payload_interceptors.go
@@ -3,9 +3,10 @@ package grpc_zap
 import (
 	"fmt"
 
-	"github.com/gengo/grpc-gateway/runtime"
 	"github.com/golang/protobuf/proto"
+	"github.com/grpc-ecosystem/go-grpc-middleware/logging"
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
+	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"golang.org/x/net/context"

--- a/logging/zap/payload_interceptors.go
+++ b/logging/zap/payload_interceptors.go
@@ -1,12 +1,10 @@
 package grpc_zap
 
 import (
-	"bytes"
 	"fmt"
 
-	"github.com/golang/protobuf/jsonpb"
+	"github.com/gengo/grpc-gateway/runtime"
 	"github.com/golang/protobuf/proto"
-	"github.com/grpc-ecosystem/go-grpc-middleware/logging"
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -14,9 +12,14 @@ import (
 	"google.golang.org/grpc"
 )
 
+// Marshaler interface for JsonPbMarshaler
+type Marshaler interface {
+	Marshal(v interface{}) ([]byte, error)
+}
+
 var (
-	// JsonPbMarshaller is the marshaller used for serializing protobuf messages.
-	JsonPbMarshaller = &jsonpb.Marshaler{}
+	// JsonPbMarshaler is the marshaler used for serializing protobuf messages.
+	JsonPbMarshaler Marshaler = &runtime.JSONPb{}
 )
 
 // PayloadUnaryServerInterceptor returns a new unary server interceptors that logs the payloads of requests.
@@ -141,9 +144,9 @@ func (j *jsonpbObjectMarshaler) MarshalLogObject(e zapcore.ObjectEncoder) error 
 }
 
 func (j *jsonpbObjectMarshaler) MarshalJSON() ([]byte, error) {
-	b := &bytes.Buffer{}
-	if err := JsonPbMarshaller.Marshal(b, j.pb); err != nil {
+	bytes, err := JsonPbMarshaler.Marshal(j.pb)
+	if err != nil {
 		return nil, fmt.Errorf("jsonpb serializer failed: %v", err)
 	}
-	return b.Bytes(), nil
+	return bytes, nil
 }


### PR DESCRIPTION
Hi,

This is a POC, just to ask if anyone would be interested on it.

Basically it allows me to do:

```
	// Replace JsonPb logger of zap with the gogo version
	grpc_zap.JsonPbMarshaler = &gateway.JSONPb{}
```

On my service, so then I can get proper payload logging with gogo types, such as *time.Time when using `gogoproto.stdtime = true`. In other words, it avoids this bug: gogo/protobuf#212

Since this is `go-grpc-middleware`, I guess as much compatibility with `gogo` as possible is desirable?

Let me know if this is interesting and if so, what should I change to make it acceptable to merge (maybe the same for Logrus logger, which would be trivial? Perhaps not import the `runtime.JSONPb` Marshaler from `grpc-gateway` to avoid that extra dependency, but have our own version?).

Thanks!