### PR TITLE
make context errors check isRetriable

### DIFF
--- a/retry/options.go
+++ b/retry/options.go
@@ -96,6 +96,8 @@ func WithCodes(retryCodes ...codes.Code) CallOption {
 //
 // A value of 0 disables the timeout overrides completely and returns to each retry call using the
 // parent `context.Deadline`.
+//
+// Note that when this is enabled, any DeadlineExceeded errors that are propagated up will be retried.
 func WithPerRetryTimeout(timeout time.Duration) CallOption {
 	return CallOption{applyFunc: func(o *options) {
 		o.perCallTimeout = timeout

--- a/retry/retry.go
+++ b/retry/retry.go
@@ -52,9 +52,10 @@ func UnaryClientInterceptor(optFuncs ...CallOption) grpc.UnaryClientInterceptor 
 					logTrace(parentCtx, "grpc_retry attempt: %d, parent context error: %v", attempt, parentCtx.Err())
 					// its the parent context deadline or cancellation.
 					return lastErr
-				} else {
+				} else if callOpts.perCallTimeout != 0 {
 					logTrace(parentCtx, "grpc_retry attempt: %d, context error from retry call", attempt)
 					// its the callCtx deadline or cancellation, in which case try again.
+					continue
 				}
 			}
 			if !isRetriable(lastErr, callOpts) {
@@ -113,7 +114,7 @@ func StreamClientInterceptor(optFuncs ...CallOption) grpc.StreamClientIntercepto
 					logTrace(parentCtx, "grpc_retry attempt: %d, parent context error: %v", attempt, parentCtx.Err())
 					// its the parent context deadline or cancellation.
 					return nil, lastErr
-				} else {
+				} else if callOpts.perCallTimeout != 0 {
 					logTrace(parentCtx, "grpc_retry attempt: %d, context error from retry call", attempt)
 					// its the callCtx deadline or cancellation, in which case try again.
 					continue
@@ -219,7 +220,7 @@ func (s *serverStreamingRetryingStream) receiveMsgAndIndicateRetry(m interface{}
 		if s.parentCtx.Err() != nil {
 			logTrace(s.parentCtx, "grpc_retry parent context error: %v", s.parentCtx.Err())
 			return false, err
-		} else {
+		} else if s.callOpts.perCallTimeout != 0 {
 			logTrace(s.parentCtx, "grpc_retry context error from retry call")
 			// its the callCtx deadline or cancellation, in which case try again.
 			return true, err

--- a/retry/retry.go
+++ b/retry/retry.go
@@ -55,7 +55,6 @@ func UnaryClientInterceptor(optFuncs ...CallOption) grpc.UnaryClientInterceptor 
 				} else {
 					logTrace(parentCtx, "grpc_retry attempt: %d, context error from retry call", attempt)
 					// its the callCtx deadline or cancellation, in which case try again.
-					continue
 				}
 			}
 			if !isRetriable(lastErr, callOpts) {

--- a/retry/retry.go
+++ b/retry/retry.go
@@ -53,8 +53,9 @@ func UnaryClientInterceptor(optFuncs ...CallOption) grpc.UnaryClientInterceptor 
 					// its the parent context deadline or cancellation.
 					return lastErr
 				} else if callOpts.perCallTimeout != 0 {
+					// We have set a perCallTimeout in the retry middleware, which would result in a context error if
+					// the deadline was exceeded, in which case try again.
 					logTrace(parentCtx, "grpc_retry attempt: %d, context error from retry call", attempt)
-					// its the callCtx deadline or cancellation, in which case try again.
 					continue
 				}
 			}
@@ -115,8 +116,9 @@ func StreamClientInterceptor(optFuncs ...CallOption) grpc.StreamClientIntercepto
 					// its the parent context deadline or cancellation.
 					return nil, lastErr
 				} else if callOpts.perCallTimeout != 0 {
+					// We have set a perCallTimeout in the retry middleware, which would result in a context error if
+					// the deadline was exceeded, in which case try again.
 					logTrace(parentCtx, "grpc_retry attempt: %d, context error from retry call", attempt)
-					// its the callCtx deadline or cancellation, in which case try again.
 					continue
 				}
 			}
@@ -221,8 +223,9 @@ func (s *serverStreamingRetryingStream) receiveMsgAndIndicateRetry(m interface{}
 			logTrace(s.parentCtx, "grpc_retry parent context error: %v", s.parentCtx.Err())
 			return false, err
 		} else if s.callOpts.perCallTimeout != 0 {
+			// We have set a perCallTimeout in the retry middleware, which would result in a context error if
+			// the deadline was exceeded, in which case try again.
 			logTrace(s.parentCtx, "grpc_retry context error from retry call")
-			// its the callCtx deadline or cancellation, in which case try again.
 			return true, err
 		}
 	}

--- a/retry/retry_test.go
+++ b/retry/retry_test.go
@@ -133,7 +133,6 @@ func (s *RetrySuite) TestUnary_FailsOnNonRetriableError() {
 	require.Error(s.T(), err, "error must occur from the failing service")
 	require.Equal(s.T(), codes.Internal, status.Code(err), "failure code must come from retrier")
 	require.EqualValues(s.T(), 1, s.srv.requestCount(), "one request should have been made")
-
 }
 
 func (s *RetrySuite) TestUnary_FailsOnNonRetriableContextError() {

--- a/retry/retry_test.go
+++ b/retry/retry_test.go
@@ -132,6 +132,16 @@ func (s *RetrySuite) TestUnary_FailsOnNonRetriableError() {
 	_, err := s.Client.Ping(s.SimpleCtx(), goodPing)
 	require.Error(s.T(), err, "error must occur from the failing service")
 	require.Equal(s.T(), codes.Internal, status.Code(err), "failure code must come from retrier")
+	require.EqualValues(s.T(), 1, s.srv.requestCount(), "one request should have been made")
+
+}
+
+func (s *RetrySuite) TestUnary_FailsOnNonRetriableContextError() {
+	s.srv.resetFailingConfiguration(5, codes.Canceled, noSleep)
+	_, err := s.Client.Ping(s.SimpleCtx(), goodPing)
+	require.Error(s.T(), err, "error must occur from the failing service")
+	require.Equal(s.T(), codes.Canceled, status.Code(err), "failure code must come from retrier")
+	require.EqualValues(s.T(), 1, s.srv.requestCount(), "one request should have been made")
 }
 
 func (s *RetrySuite) TestCallOptionsDontPanicWithoutInterceptor() {


### PR DESCRIPTION
In the current implementation, if the error is a context error from retry call, then the interceptor invokes a retry without checking `isRetriable`. This change fixes that.