### PR TITLE
Use an interface for the wrapped server stream

### DIFF
--- a/wrappers.go
+++ b/wrappers.go
@@ -8,6 +8,12 @@ import (
 	"google.golang.org/grpc"
 )
 
+// WrappedContextSettingServerStream allows setting the wrapped context of a grpc.ServerStream.
+type WrappedContextSettingServerStream interface {
+	grpc.ServerStream
+	SetContext(context.Context)
+}
+
 // WrappedServerStream is a thin wrapper around grpc.ServerStream that allows modifying context.
 type WrappedServerStream struct {
 	grpc.ServerStream
@@ -20,9 +26,14 @@ func (w *WrappedServerStream) Context() context.Context {
 	return w.WrappedContext
 }
 
+// SetContext sets the wrapper's WrappedContext, overwriting the nested grpc.ServerStream.Context()
+func (w *WrappedServerStream) SetContext(ctx context.Context) {
+	w.WrappedContext = ctx
+}
+
 // WrapServerStream returns a ServerStream that has the ability to overwrite context.
-func WrapServerStream(stream grpc.ServerStream) *WrappedServerStream {
-	if existing, ok := stream.(*WrappedServerStream); ok {
+func WrapServerStream(stream grpc.ServerStream) WrappedContextSettingServerStream {
+	if existing, ok := stream.(WrappedContextSettingServerStream); ok {
 		return existing
 	}
 	return &WrappedServerStream{ServerStream: stream, WrappedContext: stream.Context()}


### PR DESCRIPTION
I need the WrappedServerStream to satisfy an interface, that way other grpc interceptors/middlewares can both use and look for this interface.

My use case:
I am using a grpc interceptor/middleware that adds a "Request ID" onto each incoming grpc request.
I am chaining it with a second interceptor that logs all requests (the logrus payload logging).

I want downstream middlewares to be able to use and set the Context.  Currently, they are unable to, because the logging middleware wraps the ServerStream in its own different wrapper (`loggingServerStream`).

If this PR is accepted, we could then make `loggingServerStream` (and other custom wrappers) also implement `WrappedContextSettingServerStream`, allowing your middleware function `WrapServerStream` to be used and useful everywhere.
