### PR TITLE
Remove duplicate peer.address field

### DIFF
--- a/tags/interceptors.go
+++ b/tags/interceptors.go
@@ -67,9 +67,6 @@ func (w *wrappedStream) RecvMsg(m interface{}) error {
 
 func newTagsForCtx(ctx context.Context) context.Context {
 	t := newTags()
-	if peer, ok := peer.FromContext(ctx); ok {
-		t.Set("peer.address", peer.Addr.String())
-	}
 	return setInContext(ctx, t)
 }
 

--- a/tags/interceptors.go
+++ b/tags/interceptors.go
@@ -7,7 +7,6 @@ import (
 	"github.com/grpc-ecosystem/go-grpc-middleware"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/peer"
 )
 
 // UnaryServerInterceptor returns a new unary server interceptors that sets the values for request tags.


### PR DESCRIPTION
Current issue - `peer.address` is duplicated in the zap logger middleware:

```
{"level":"info","ts":1538680314.2086248,"logger":"grpc","caller":"zap/server_interceptors.go:40","msg":"finished unary call with code OK","peer.address":"127.0.0.1:50180","grpc.start_time":"2018-10-04T12:11:54-07:00","system":"grpc","span.kind":"server","grpc.service":"pinpoint.PinpointCore","grpc.method":"GetStatus","peer.address":"127.0.0.1:50180","grpc.code":"OK","grpc.time":0.000100797}
```

Closes #146