### PR TITLE
Update payload_interceptors.go

### DIFF
--- a/logging/logrus/payload_interceptors.go
+++ b/logging/logrus/payload_interceptors.go
@@ -32,7 +32,7 @@ func PayloadUnaryServerInterceptor(entry *logrus.Entry, decider grpc_logging.Ser
 		logProtoMessageAsJson(logEntry, req, "grpc.request.content", "server request payload logged as grpc.request.content field")
 		resp, err := handler(ctx, req)
 		if err == nil {
-			logProtoMessageAsJson(logEntry, resp, "grpc.response.content", "server response payload logged as grpc.request.content field")
+			logProtoMessageAsJson(logEntry, resp, "grpc.response.content", "server response payload logged as grpc.response.content field")
 		}
 		return resp, err
 	}


### PR DESCRIPTION
Update incorrect logging message in `PayloadUnaryServerInterceptor` from:
`"server response payload logged as grpc.request.content field"`
to
`"server response payload logged as grpc.response.content field"`