### PR TITLE
change recover default error format

### DIFF
--- a/recovery/interceptors.go
+++ b/recovery/interceptors.go
@@ -42,7 +42,7 @@ func StreamServerInterceptor(opts ...Option) grpc.StreamServerInterceptor {
 
 func recoverFrom(p interface{}, r RecoveryHandlerFunc) error {
 	if r == nil {
-		return grpc.Errorf(codes.Internal, "%s", p)
+		return grpc.Errorf(codes.Internal, "%#v", p)
 	}
 	return r(p)
 }


### PR DESCRIPTION
According to [fmt.Printf](https://golang.org/pkg/fmt/#hdr-Printing), `%#v` maybe better than `%s`.