### PR TITLE
change recover default error format

### DIFF
--- a/recovery/interceptors.go
+++ b/recovery/interceptors.go
@@ -4,6 +4,7 @@
 package grpc_recovery
 
 import (
+	"fmt"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -42,7 +43,13 @@ func StreamServerInterceptor(opts ...Option) grpc.StreamServerInterceptor {
 
 func recoverFrom(p interface{}, r RecoveryHandlerFunc) error {
 	if r == nil {
-		return grpc.Errorf(codes.Internal, "%s", p)
+		switch p.(type) {
+		case string:
+		case fmt.Stringer:
+			return grpc.Errorf(codes.Internal, "%s", p)
+		default:
+			return grpc.Errorf(codes.Internal, "%#v", p)
+		}
 	}
 	return r(p)
 }

--- a/recovery/interceptors.go
+++ b/recovery/interceptors.go
@@ -42,14 +42,14 @@ func StreamServerInterceptor(opts ...Option) grpc.StreamServerInterceptor {
 }
 
 func recoverFrom(p interface{}, r RecoveryHandlerFunc) error {
-	if r == nil {
-		switch p.(type) {
-		case string:
-		case fmt.Stringer:
-			return grpc.Errorf(codes.Internal, "%s", p)
-		default:
-			return grpc.Errorf(codes.Internal, "%#v", p)
-		}
+	if r != nil {
+		return r(p)
 	}
-	return r(p)
+
+	switch p.(type) {
+	case string, fmt.Stringer:
+		return grpc.Errorf(codes.Internal, "%s", p)
+	}
+
+	return grpc.Errorf(codes.Internal, "%#v", p)
 }


### PR DESCRIPTION
According to [fmt.Printf](https://golang.org/pkg/fmt/#hdr-Printing), `%#v` maybe better than `%s`.