### PR TITLE
Relax dependency's version constraints

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -20,10 +20,10 @@
   version = "v0.5"
 
 [[projects]]
-  branch = "master"
   name = "github.com/golang/protobuf"
   packages = ["jsonpb","proto","ptypes","ptypes/any","ptypes/duration","ptypes/struct","ptypes/timestamp"]
-  revision = "1e59b77b52bf8e4b449a57e6f79f21226d571845"
+  revision = "aa810b61a9c79d51363740d207bb46cf8e620ed5"
+  version = "v1.2.0"
 
 [[projects]]
   name = "github.com/opentracing/opentracing-go"
@@ -118,6 +118,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "b24c6670412eb0bc44ed1db77fecc52333f8725f3e3272bdc568f5683a63031f"
+  inputs-digest = "1678bde612645b1671ec594bc50b5369753881b30bc43d958aca6dd051c8a06f"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -1,35 +1,33 @@
 [[constraint]]
   name = "github.com/gogo/protobuf"
-  version = "0.5.0"
+  version = "^0.5"
 
 [[constraint]]
-  branch = "master"
   name = "github.com/golang/protobuf"
+  version = "^1.0"
 
 [[constraint]]
   name = "github.com/opentracing/opentracing-go"
-  version = "1.0.2"
+  version = "^1.0"
 
 [[constraint]]
   name = "github.com/sirupsen/logrus"
-  version = "1.0.3"
+  version = "^1.0"
 
 [[constraint]]
   name = "github.com/stretchr/testify"
-  version = "1.1.4"
+  version = "^1.1"
 
 [[constraint]]
   name = "go.uber.org/zap"
-  version = "1.7.1"
+  version = "^1.7"
 
 [[constraint]]
-  branch = "master"
   name = "golang.org/x/net"
 
 [[constraint]]
-  branch = "master"
   name = "golang.org/x/oauth2"
 
 [[constraint]]
   name = "google.golang.org/grpc"
-  version = "1.8.0"
+  version = "^1.8"


### PR DESCRIPTION
## WHY
currently, this package has `Gopkg.toml` and it pins the dependency's version.
but this often occurs a version conflict: for example, our project depends on `google/protobuf@^v1.2.0` and `go-grpc-middleware@^v1.0.0`, but go-grpc-middleware pins `google/protobuf`'s version on `master`. so it causes the version conflict, we should override `google/protobuf` version.


## WHAT

Relax version constraints in `Gopkt.toml`