### PR TITLE
fixed duplicate custom&peer.address field

### DIFF
--- a/logging/zap/server_interceptors.go
+++ b/logging/zap/server_interceptors.go
@@ -86,7 +86,7 @@ func serverCallFields(fullMethodString string) []zapcore.Field {
 }
 
 func newLoggerForCall(ctx context.Context, logger *zap.Logger, fullMethodString string, start time.Time) context.Context {
-	f := ctxzap.TagsToFields(ctx)
+	var f []zapcore.Field
 	f = append(f, zap.String("grpc.start_time", start.Format(time.RFC3339)))
 	if d, ok := ctx.Deadline(); ok {
 		f = append(f, zap.String("grpc.request.deadline", d.Format(time.RFC3339)))


### PR DESCRIPTION
fix #120 #166  , zap will not cleanup duplicate field but logrus will. so can't call ctxzap.TagsToFields() twice.