### PR TITLE
Include the option to set a max attempts grpc metadata header

### DIFF
--- a/retry/options.go
+++ b/retry/options.go
@@ -19,10 +19,11 @@ var (
 	DefaultRetriableCodes = []codes.Code{codes.ResourceExhausted, codes.Unavailable}
 
 	defaultOptions = &options{
-		max:            0, // disabed
-		perCallTimeout: 0, // disabled
-		includeHeader:  true,
-		codes:          DefaultRetriableCodes,
+		max:              0, // disabled
+		perCallTimeout:   0, // disabled
+		includeHeader:    true,
+		includeMaxHeader: false,
+		codes:            DefaultRetriableCodes,
 		backoffFunc: BackoffFuncContext(func(ctx context.Context, attempt uint) time.Duration {
 			return BackoffLinearWithJitter(50*time.Millisecond /*jitter*/, 0.10)(attempt)
 		}),
@@ -102,12 +103,23 @@ func WithPerRetryTimeout(timeout time.Duration) CallOption {
 	}}
 }
 
+// WithMaxAttemptsHeader sets an option that will include a header with the maximum number of
+// retry attempts that will be made.
+//
+// This could be used for observability to know how many retries will be attempted.
+func WithMaxAttemptsHeader() CallOption {
+	return CallOption{applyFunc: func(o *options) {
+		o.includeMaxHeader = true
+	}}
+}
+
 type options struct {
-	max            uint
-	perCallTimeout time.Duration
-	includeHeader  bool
-	codes          []codes.Code
-	backoffFunc    BackoffFuncContext
+	max              uint
+	perCallTimeout   time.Duration
+	includeHeader    bool
+	includeMaxHeader bool
+	codes            []codes.Code
+	backoffFunc      BackoffFuncContext
 }
 
 // CallOption is a grpc.CallOption that is local to grpc_retry.


### PR DESCRIPTION
In my observability code, I want to be able to distinguish between a call that will result in only a single call (where retry is disable) and a call where if there is a failure, it will be retried.

The current code doesn't allow that because the first call has no metadata set on it and all subsequent calls have an attempt set into the metadata.

This would add a max attempts value to all grpc calls that could be retried.

I disabled the option by default because to not increase the overhead of retries by default.