### PR TITLE
Make tests run on IPv6-only environments

### DIFF
--- a/testing/interceptor_suite.go
+++ b/testing/interceptor_suite.go
@@ -50,14 +50,14 @@ func (s *InterceptorTestSuite) SetupSuite() {
 	s.restartServerWithDelayedStart = make(chan time.Duration)
 	s.serverRunning = make(chan bool)
 
-	s.serverAddr = "127.0.0.1:0"
+	s.serverAddr = ":0"
 
 	go func() {
 		for {
 			var err error
 			s.ServerListener, err = net.Listen("tcp", s.serverAddr)
-			s.serverAddr = s.ServerListener.Addr().String()
 			require.NoError(s.T(), err, "must be able to allocate a port for serverListener")
+			s.serverAddr = s.ServerListener.Addr().String()
 			if *flagTls {
 				creds, err := credentials.NewServerTLSFromFile(
 					path.Join(getTestingCertsPath(), "localhost.crt"),


### PR DESCRIPTION
The hostname defaults to the loopback interface so there's no need to specify an IPv4 loopback address.

Also, move the `net.Listen` error check up in order to get clearer error messages if the `net.Listen` call returns an error. Without this change, when `net.Listen` fails, `s.ServerListener` ends up being nil and the next line calling `Addr()` on it results in a segmentation fault.