### PR TITLE
`middleare` -> `middleware`

### DIFF
--- a/ratelimit/ratelimit.go
+++ b/ratelimit/ratelimit.go
@@ -18,7 +18,7 @@ type Limiter interface {
 func UnaryServerInterceptor(limiter Limiter) grpc.UnaryServerInterceptor {
 	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
 		if limiter.Limit() {
-			return nil, status.Errorf(codes.ResourceExhausted, "%s is rejected by grpc_ratelimit middleare, please retry later.", info.FullMethod)
+			return nil, status.Errorf(codes.ResourceExhausted, "%s is rejected by grpc_ratelimit middleware, please retry later.", info.FullMethod)
 		}
 		return handler(ctx, req)
 	}
@@ -28,7 +28,7 @@ func UnaryServerInterceptor(limiter Limiter) grpc.UnaryServerInterceptor {
 func StreamServerInterceptor(limiter Limiter) grpc.StreamServerInterceptor {
 	return func(srv interface{}, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
 		if limiter.Limit() {
-			return status.Errorf(codes.ResourceExhausted, "%s is rejected by grpc_ratelimit middleare, please retry later.", info.FullMethod)
+			return status.Errorf(codes.ResourceExhausted, "%s is rejected by grpc_ratelimit middleware, please retry later.", info.FullMethod)
 		}
 		return handler(srv, stream)
 	}

--- a/ratelimit/ratelimit_test.go
+++ b/ratelimit/ratelimit_test.go
@@ -47,7 +47,7 @@ func TestUnaryServerInterceptor_RateLimitFail(t *testing.T) {
 	}
 	req, err := interceptor(nil, nil, info, handler)
 	assert.Nil(t, req)
-	assert.EqualError(t, err, "rpc error: code = ResourceExhausted desc = FakeMethod is rejected by grpc_ratelimit middleare, please retry later.")
+	assert.EqualError(t, err, "rpc error: code = ResourceExhausted desc = FakeMethod is rejected by grpc_ratelimit middleware, please retry later.")
 }
 
 func TestStreamServerInterceptor_RateLimitPass(t *testing.T) {
@@ -71,5 +71,5 @@ func TestStreamServerInterceptor_RateLimitFail(t *testing.T) {
 		FullMethod: "FakeMethod",
 	}
 	err := interceptor(nil, nil, info, handler)
-	assert.EqualError(t, err, "rpc error: code = ResourceExhausted desc = FakeMethod is rejected by grpc_ratelimit middleare, please retry later.")
+	assert.EqualError(t, err, "rpc error: code = ResourceExhausted desc = FakeMethod is rejected by grpc_ratelimit middleware, please retry later.")
 }


### PR DESCRIPTION
Fixing small typo in the rate limiter middleware