### PR TITLE
gRPC Zap ReplaceGrpcLoggerV2

### DIFF
--- a/logging/zap/doc.go
+++ b/logging/zap/doc.go
@@ -15,7 +15,7 @@ logged as structured `jsonpb` fields for every message received/sent (both unary
 `Payload*Interceptor` functions for that. Please note that the user-provided function that determines whetether to log
 the full request/response payload needs to be written with care, this can significantly slow down gRPC.
 
-ZAP can also be made as a backend for gRPC library internals. For that use `ReplaceGrpcLogger`.
+ZAP can also be made as a backend for gRPC library internals. For that use `ReplaceGrpcLoggerV2`.
 
 
 *Server Interceptor*

--- a/logging/zap/examples_test.go
+++ b/logging/zap/examples_test.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"time"
 
-	"github.com/grpc-ecosystem/go-grpc-middleware"
-	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap"
-	"github.com/grpc-ecosystem/go-grpc-middleware/tags"
-	"github.com/grpc-ecosystem/go-grpc-middleware/tags/zap"
+	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
+	grpc_zap "github.com/grpc-ecosystem/go-grpc-middleware/logging/zap"
+	grpc_ctxtags "github.com/grpc-ecosystem/go-grpc-middleware/tags"
+	ctx_zap "github.com/grpc-ecosystem/go-grpc-middleware/tags/zap"
 	pb_testproto "github.com/grpc-ecosystem/go-grpc-middleware/testing/testproto"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -26,7 +26,7 @@ func Example_initialization() {
 		grpc_zap.WithLevels(customFunc),
 	}
 	// Make sure that log statements internal to gRPC library are logged using the zapLogger as well.
-	grpc_zap.ReplaceGrpcLogger(zapLogger)
+	grpc_zap.ReplaceGrpcLoggerV2(zapLogger)
 	// Create a server, make sure we put the grpc_ctxtags context before everything else.
 	_ = grpc.NewServer(
 		grpc_middleware.WithUnaryServerChain(

--- a/logging/zap/examples_test.go
+++ b/logging/zap/examples_test.go
@@ -26,7 +26,7 @@ func Example_initialization() {
 		grpc_zap.WithLevels(customFunc),
 	}
 	// Make sure that log statements internal to gRPC library are logged using the zapLogger as well.
-	grpc_zap.ReplaceGrpcLoggerV2(zapLogger, grpc_zap.DefaultGrpcLoggerV2Options)
+	grpc_zap.ReplaceGrpcLoggerV2(zapLogger)
 	// Create a server, make sure we put the grpc_ctxtags context before everything else.
 	_ = grpc.NewServer(
 		grpc_middleware.WithUnaryServerChain(

--- a/logging/zap/examples_test.go
+++ b/logging/zap/examples_test.go
@@ -26,7 +26,7 @@ func Example_initialization() {
 		grpc_zap.WithLevels(customFunc),
 	}
 	// Make sure that log statements internal to gRPC library are logged using the zapLogger as well.
-	grpc_zap.ReplaceGrpcLoggerV2(zapLogger)
+	grpc_zap.ReplaceGrpcLoggerV2(zapLogger, grpc_zap.DefaultGrpcLoggerV2Options)
 	// Create a server, make sure we put the grpc_ctxtags context before everything else.
 	_ = grpc.NewServer(
 		grpc_middleware.WithUnaryServerChain(

--- a/logging/zap/grpclogger.go
+++ b/logging/zap/grpclogger.go
@@ -65,12 +65,6 @@ func ReplaceGrpcLoggerV2(logger *zap.Logger, opts *GrpcLoggerV2Options) {
 	grpclog.SetLoggerV2(zgl)
 }
 
-const (
-	errorLevel = iota
-	warnLevel
-	infoLevel
-)
-
 type zapGrpcLoggerV2 struct {
 	*zap.Logger
 	verbosity int

--- a/logging/zap/grpclogger.go
+++ b/logging/zap/grpclogger.go
@@ -53,8 +53,11 @@ func ReplaceGrpcLoggerV2(logger *zap.Logger) {
 }
 
 // ReplaceGrpcLoggerV2WithVerosity replaces the grpc_.LoggerV2 with the provided logger and verbosity.
-func ReplaceGrpcLoggerV2WithVerosity(logger *zap.Logger, verosity int) {
-	zgl := &zapGrpcLoggerV2{Logger: logger.With(SystemField, zap.Bool("grpc_log", true))}
+func ReplaceGrpcLoggerV2WithVerosity(logger *zap.Logger, verbosity int) {
+	zgl := &zapGrpcLoggerV2{
+		Logger:    logger.With(SystemField, zap.Bool("grpc_log", true)),
+		verbosity: verbosity,
+	}
 	grpclog.SetLoggerV2(zgl)
 }
 

--- a/logging/zap/grpclogger.go
+++ b/logging/zap/grpclogger.go
@@ -54,63 +54,63 @@ func ReplaceGrpcLoggerV2(logger *zap.Logger) {
 // ReplaceGrpcLoggerV2WithVerbosity replaces the grpc_.LoggerV2 with the provided logger and verbosity.
 func ReplaceGrpcLoggerV2WithVerbosity(logger *zap.Logger, verbosity int) {
 	zgl := &zapGrpcLoggerV2{
-		Logger:    logger.With(SystemField, zap.Bool("grpc_log", true)),
+		logger:    logger.With(SystemField, zap.Bool("grpc_log", true)),
 		verbosity: verbosity,
 	}
 	grpclog.SetLoggerV2(zgl)
 }
 
 type zapGrpcLoggerV2 struct {
-	*zap.Logger
+	logger    *zap.Logger
 	verbosity int
 }
 
 func (l *zapGrpcLoggerV2) Info(args ...interface{}) {
-	l.Logger.Info(fmt.Sprint(args...))
+	l.logger.Info(fmt.Sprint(args...))
 }
 
 func (l *zapGrpcLoggerV2) Infoln(args ...interface{}) {
-	l.Logger.Info(fmt.Sprint(args...))
+	l.logger.Info(fmt.Sprint(args...))
 }
 
 func (l *zapGrpcLoggerV2) Infof(format string, args ...interface{}) {
-	l.Logger.Info(fmt.Sprintf(format, args...))
+	l.logger.Info(fmt.Sprintf(format, args...))
 }
 
 func (l *zapGrpcLoggerV2) Warning(args ...interface{}) {
-	l.Logger.Warn(fmt.Sprint(args...))
+	l.logger.Warn(fmt.Sprint(args...))
 }
 
 func (l *zapGrpcLoggerV2) Warningln(args ...interface{}) {
-	l.Logger.Warn(fmt.Sprint(args...))
+	l.logger.Warn(fmt.Sprint(args...))
 }
 
 func (l *zapGrpcLoggerV2) Warningf(format string, args ...interface{}) {
-	l.Logger.Warn(fmt.Sprintf(format, args...))
+	l.logger.Warn(fmt.Sprintf(format, args...))
 }
 
 func (l *zapGrpcLoggerV2) Error(args ...interface{}) {
-	l.Logger.Error(fmt.Sprint(args...))
+	l.logger.Error(fmt.Sprint(args...))
 }
 
 func (l *zapGrpcLoggerV2) Errorln(args ...interface{}) {
-	l.Logger.Error(fmt.Sprint(args...))
+	l.logger.Error(fmt.Sprint(args...))
 }
 
 func (l *zapGrpcLoggerV2) Errorf(format string, args ...interface{}) {
-	l.Logger.Error(fmt.Sprintf(format, args...))
+	l.logger.Error(fmt.Sprintf(format, args...))
 }
 
 func (l *zapGrpcLoggerV2) Fatal(args ...interface{}) {
-	l.Logger.Fatal(fmt.Sprint(args...))
+	l.logger.Fatal(fmt.Sprint(args...))
 }
 
 func (l *zapGrpcLoggerV2) Fatalln(args ...interface{}) {
-	l.Logger.Fatal(fmt.Sprint(args...))
+	l.logger.Fatal(fmt.Sprint(args...))
 }
 
 func (l *zapGrpcLoggerV2) Fatalf(format string, args ...interface{}) {
-	l.Logger.Fatal(fmt.Sprintf(format, args...))
+	l.logger.Fatal(fmt.Sprintf(format, args...))
 }
 
 func (l *zapGrpcLoggerV2) V(level int) bool {

--- a/logging/zap/grpclogger.go
+++ b/logging/zap/grpclogger.go
@@ -12,7 +12,7 @@ import (
 
 // ReplaceGrpcLogger sets the given zap.Logger as a gRPC-level logger.
 // This should be called *before* any other initialization, preferably from init() functions.
-// Deprecated: use ReplaceLoggerV2.
+// Deprecated: use ReplaceGrpcLoggerV2.
 func ReplaceGrpcLogger(logger *zap.Logger) {
 	zgl := &zapGrpcLogger{logger.With(SystemField, zap.Bool("grpc_log", true))}
 	grpclog.SetLogger(zgl)

--- a/logging/zap/grpclogger.go
+++ b/logging/zap/grpclogger.go
@@ -5,6 +5,8 @@ package grpc_zap
 
 import (
 	"fmt"
+	"os"
+	"strconv"
 
 	"go.uber.org/zap"
 	"google.golang.org/grpc/grpclog"
@@ -12,6 +14,7 @@ import (
 
 // ReplaceGrpcLogger sets the given zap.Logger as a gRPC-level logger.
 // This should be called *before* any other initialization, preferably from init() functions.
+// Deprecated: use ReplaceGrpcLoggerV2
 func ReplaceGrpcLogger(logger *zap.Logger) {
 	zgl := &zapGrpcLogger{logger.With(SystemField, zap.Bool("grpc_log", true))}
 	grpclog.SetLogger(zgl)
@@ -43,4 +46,104 @@ func (l *zapGrpcLogger) Printf(format string, args ...interface{}) {
 
 func (l *zapGrpcLogger) Println(args ...interface{}) {
 	l.logger.Info(fmt.Sprint(args...))
+}
+
+// ReplaceGrpcLoggerV2 replaces the grpc_log.LoggerV2 with the input zap.Logger
+// This logger adheres to the grpc go environment variables GRPC_GO_LOG_VERBOSITY_LEVEL and GRPC_GO_LOG_SEVERITY_LEVEL.
+func ReplaceGrpcLoggerV2(logger *zap.Logger) {
+	zgl := &zapGrpcLoggerV2{Logger: logger.With(SystemField, zap.Bool("grpc_log", true))}
+
+	verbosity := os.Getenv("GRPC_GO_LOG_VERBOSITY_LEVEL")
+	if v, err := strconv.Atoi(verbosity); err == nil {
+		zgl.verbosity = v
+	}
+
+	// We don't want to change the zap core of the input logger so we won't set logger level of input zap.Logger
+	logLevel := os.Getenv("GRPC_GO_LOG_SEVERITY_LEVEL")
+	switch logLevel {
+	case "", "ERROR", "error": // If env is unset, set level to ERROR.
+		zgl.severity = errorLevel
+	case "WARNING", "warning":
+		zgl.severity = warnLevel
+	case "INFO", "info":
+		zgl.severity = infoLevel
+	}
+
+	grpclog.SetLoggerV2(zgl)
+}
+
+const (
+	errorLevel = iota
+	warnLevel
+	infoLevel
+)
+
+type zapGrpcLoggerV2 struct {
+	*zap.Logger
+	verbosity int
+	severity  int
+}
+
+func (l *zapGrpcLoggerV2) Info(args ...interface{}) {
+	if l.severity >= infoLevel {
+		l.Logger.Info(fmt.Sprint(args...))
+	}
+}
+
+func (l *zapGrpcLoggerV2) Infoln(args ...interface{}) {
+	if l.severity >= infoLevel {
+		l.Logger.Info(fmt.Sprint(args...))
+	}
+}
+
+func (l *zapGrpcLoggerV2) Infof(format string, args ...interface{}) {
+	if l.severity >= infoLevel {
+		l.Logger.Info(fmt.Sprintf(format, args...))
+	}
+}
+
+func (l *zapGrpcLoggerV2) Warning(args ...interface{}) {
+	if l.severity >= warnLevel {
+		l.Logger.Warn(fmt.Sprint(args...))
+	}
+}
+
+func (l *zapGrpcLoggerV2) Warningln(args ...interface{}) {
+	if l.severity >= warnLevel {
+		l.Logger.Warn(fmt.Sprint(args...))
+	}
+}
+
+func (l *zapGrpcLoggerV2) Warningf(format string, args ...interface{}) {
+	if l.severity >= warnLevel {
+		l.Logger.Warn(fmt.Sprintf(format, args...))
+	}
+}
+
+func (l *zapGrpcLoggerV2) Error(args ...interface{}) {
+	l.Logger.Error(fmt.Sprint(args...))
+}
+
+func (l *zapGrpcLoggerV2) Errorln(args ...interface{}) {
+	l.Logger.Error(fmt.Sprint(args...))
+}
+
+func (l *zapGrpcLoggerV2) Errorf(format string, args ...interface{}) {
+	l.Logger.Error(fmt.Sprintf(format, args...))
+}
+
+func (l *zapGrpcLoggerV2) Fatal(args ...interface{}) {
+	l.Logger.Fatal(fmt.Sprint(args...))
+}
+
+func (l *zapGrpcLoggerV2) Fatalln(args ...interface{}) {
+	l.Logger.Fatal(fmt.Sprint(args...))
+}
+
+func (l *zapGrpcLoggerV2) Fatalf(format string, args ...interface{}) {
+	l.Logger.Fatal(fmt.Sprintf(format, args...))
+}
+
+func (l *zapGrpcLoggerV2) V(level int) bool {
+	return level <= l.verbosity
 }

--- a/logging/zap/grpclogger.go
+++ b/logging/zap/grpclogger.go
@@ -74,43 +74,30 @@ const (
 type zapGrpcLoggerV2 struct {
 	*zap.Logger
 	verbosity int
-	severity  int
 }
 
 func (l *zapGrpcLoggerV2) Info(args ...interface{}) {
-	if l.severity >= infoLevel {
-		l.Logger.Info(fmt.Sprint(args...))
-	}
+	l.Logger.Info(fmt.Sprint(args...))
 }
 
 func (l *zapGrpcLoggerV2) Infoln(args ...interface{}) {
-	if l.severity >= infoLevel {
-		l.Logger.Info(fmt.Sprint(args...))
-	}
+	l.Logger.Info(fmt.Sprint(args...))
 }
 
 func (l *zapGrpcLoggerV2) Infof(format string, args ...interface{}) {
-	if l.severity >= infoLevel {
-		l.Logger.Info(fmt.Sprintf(format, args...))
-	}
+	l.Logger.Info(fmt.Sprintf(format, args...))
 }
 
 func (l *zapGrpcLoggerV2) Warning(args ...interface{}) {
-	if l.severity >= warnLevel {
-		l.Logger.Warn(fmt.Sprint(args...))
-	}
+	l.Logger.Warn(fmt.Sprint(args...))
 }
 
 func (l *zapGrpcLoggerV2) Warningln(args ...interface{}) {
-	if l.severity >= warnLevel {
-		l.Logger.Warn(fmt.Sprint(args...))
-	}
+	l.Logger.Warn(fmt.Sprint(args...))
 }
 
 func (l *zapGrpcLoggerV2) Warningf(format string, args ...interface{}) {
-	if l.severity >= warnLevel {
-		l.Logger.Warn(fmt.Sprintf(format, args...))
-	}
+	l.Logger.Warn(fmt.Sprintf(format, args...))
 }
 
 func (l *zapGrpcLoggerV2) Error(args ...interface{}) {

--- a/logging/zap/grpclogger.go
+++ b/logging/zap/grpclogger.go
@@ -12,7 +12,7 @@ import (
 
 // ReplaceGrpcLogger sets the given zap.Logger as a gRPC-level logger.
 // This should be called *before* any other initialization, preferably from init() functions.
-// Deprecated: use ReplaceGrpcLoggerV2.
+// Deprecated: use ReplaceLoggerV2.
 func ReplaceGrpcLogger(logger *zap.Logger) {
 	zgl := &zapGrpcLogger{logger.With(SystemField, zap.Bool("grpc_log", true))}
 	grpclog.SetLogger(zgl)
@@ -46,23 +46,15 @@ func (l *zapGrpcLogger) Println(args ...interface{}) {
 	l.logger.Info(fmt.Sprint(args...))
 }
 
-// GrpcLoggerV2Options allows you to set grpclogger options when using ReplaceGrpcLoggerV2.
-type GrpcLoggerV2Options struct {
-	verbosity int
-}
-
-// DefaultGrpcLoggerV2Options is a set of default options for ReplaceGrpcLoggerV2.
-var DefaultGrpcLoggerV2Options = &GrpcLoggerV2Options{}
-
 // ReplaceGrpcLoggerV2 replaces the grpc_log.LoggerV2 with the input zap.Logger.
 // This logger allows you to set grpc verbosity level.
-func ReplaceGrpcLoggerV2(logger *zap.Logger, opts *GrpcLoggerV2Options) {
+func ReplaceGrpcLoggerV2(logger *zap.Logger) {
+	ReplaceGrpcLoggerV2WithVerosity(logger, 0)
+}
+
+// ReplaceGrpcLoggerV2WithVerosity replaces the grpc_.LoggerV2 with the provided logger and verbosity.
+func ReplaceGrpcLoggerV2WithVerosity(logger *zap.Logger, verosity int) {
 	zgl := &zapGrpcLoggerV2{Logger: logger.With(SystemField, zap.Bool("grpc_log", true))}
-
-	if opts != nil {
-		zgl.verbosity = opts.verbosity
-	}
-
 	grpclog.SetLoggerV2(zgl)
 }
 

--- a/logging/zap/grpclogger.go
+++ b/logging/zap/grpclogger.go
@@ -12,7 +12,7 @@ import (
 
 // ReplaceGrpcLogger sets the given zap.Logger as a gRPC-level logger.
 // This should be called *before* any other initialization, preferably from init() functions.
-// Deprecated: use ReplaceGrpcLoggerV2
+// Deprecated: use ReplaceGrpcLoggerV2.
 func ReplaceGrpcLogger(logger *zap.Logger) {
 	zgl := &zapGrpcLogger{logger.With(SystemField, zap.Bool("grpc_log", true))}
 	grpclog.SetLogger(zgl)
@@ -46,16 +46,16 @@ func (l *zapGrpcLogger) Println(args ...interface{}) {
 	l.logger.Info(fmt.Sprint(args...))
 }
 
-// GrpcLoggerV2Options allows you to set grpclogger options when using ReplaceGrpcLoggerV2
+// GrpcLoggerV2Options allows you to set grpclogger options when using ReplaceGrpcLoggerV2.
 type GrpcLoggerV2Options struct {
 	verbosity int
 }
 
-// DefaultGrpcLoggerV2Options is a set of sane default options for ReplaceGrpcLoggerV2
+// DefaultGrpcLoggerV2Options is a set of default options for ReplaceGrpcLoggerV2.
 var DefaultGrpcLoggerV2Options = &GrpcLoggerV2Options{}
 
-// ReplaceGrpcLoggerV2 replaces the grpc_log.LoggerV2 with the input zap.Logger
-// This logger allows you to set grpc verbosity level
+// ReplaceGrpcLoggerV2 replaces the grpc_log.LoggerV2 with the input zap.Logger.
+// This logger allows you to set grpc verbosity level.
 func ReplaceGrpcLoggerV2(logger *zap.Logger, opts *GrpcLoggerV2Options) {
 	zgl := &zapGrpcLoggerV2{Logger: logger.With(SystemField, zap.Bool("grpc_log", true))}
 

--- a/logging/zap/grpclogger.go
+++ b/logging/zap/grpclogger.go
@@ -46,11 +46,12 @@ func (l *zapGrpcLogger) Println(args ...interface{}) {
 	l.logger.Info(fmt.Sprint(args...))
 }
 
+// GrpcLoggerV2Options allows you to set grpclogger options when using ReplaceGrpcLoggerV2
 type GrpcLoggerV2Options struct {
 	verbosity int
 }
 
-// DefaultGrpcLoggerV2Options is the default options for ReplaceGrpcLoggerV2
+// DefaultGrpcLoggerV2Options is a set of sane default options for ReplaceGrpcLoggerV2
 var DefaultGrpcLoggerV2Options = &GrpcLoggerV2Options{}
 
 // ReplaceGrpcLoggerV2 replaces the grpc_log.LoggerV2 with the input zap.Logger

--- a/logging/zap/grpclogger.go
+++ b/logging/zap/grpclogger.go
@@ -46,14 +46,13 @@ func (l *zapGrpcLogger) Println(args ...interface{}) {
 	l.logger.Info(fmt.Sprint(args...))
 }
 
-// ReplaceGrpcLoggerV2 replaces the grpc_log.LoggerV2 with the input zap.Logger.
-// This logger allows you to set grpc verbosity level.
+// ReplaceGrpcLoggerV2 replaces the grpc_log.LoggerV2 with the provided logger.
 func ReplaceGrpcLoggerV2(logger *zap.Logger) {
-	ReplaceGrpcLoggerV2WithVerosity(logger, 0)
+	ReplaceGrpcLoggerV2WithVerbosity(logger, 0)
 }
 
-// ReplaceGrpcLoggerV2WithVerosity replaces the grpc_.LoggerV2 with the provided logger and verbosity.
-func ReplaceGrpcLoggerV2WithVerosity(logger *zap.Logger, verbosity int) {
+// ReplaceGrpcLoggerV2WithVerbosity replaces the grpc_.LoggerV2 with the provided logger and verbosity.
+func ReplaceGrpcLoggerV2WithVerbosity(logger *zap.Logger, verbosity int) {
 	zgl := &zapGrpcLoggerV2{
 		Logger:    logger.With(SystemField, zap.Bool("grpc_log", true)),
 		verbosity: verbosity,


### PR DESCRIPTION
We at Hootsuite were noticing noisy logs coming from grpc and we noticed it's because grpc_zap implements logger v1 interface. We need the logger v2 implemented instead, so I have opened this PR.

This is a revived and comments addressed version of #144 which was opened by @jamisonhyatt. Feel free to just merge this in after approval if it looks good!