### PR TITLE
Add zerolog logging middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ myServer := grpc.NewServer(
    * [`grpc_ctxtags`](tags/) - a library that adds a `Tag` map to context, with data populated from request body
    * [`grpc_zap`](logging/zap/) - integration of [zap](https://github.com/uber-go/zap) logging library into gRPC handlers.
    * [`grpc_logrus`](logging/logrus/) - integration of [logrus](https://github.com/sirupsen/logrus) logging library into gRPC handlers.
-
+   * [`grpc_zerolog`](logging/zerolog/) - integration of [zerolog](https://github.com/rs/zerolog) logging library into gRPC handlers.
 
 #### Monitoring
    * [`grpc_prometheus`⚡](https://github.com/grpc-ecosystem/go-grpc-prometheus) - Prometheus client-side and server-side monitoring middleware

--- a/logging/doc.go
+++ b/logging/doc.go
@@ -28,7 +28,7 @@ https://github.com/opentracing/specification/blob/master/semantic_conventions.md
 
 Implementations
 
-There are two implementations at the moment: logrus and zap
+There are three implementations at the moment: logrus, zap and zerolog
 
 See relevant packages below.
 */

--- a/logging/zerolog/client_interceptors.go
+++ b/logging/zerolog/client_interceptors.go
@@ -1,7 +1,4 @@
-// Copyright 2017 Michal Witkowski. All Rights Reserved.
-// See LICENSE for licensing terms.
-
-package grpc_zerolog
+package zerolog
 
 import (
 	"context"
@@ -10,11 +7,6 @@ import (
 	"google.golang.org/grpc"
 	"path"
 	"time"
-)
-
-var (
-// ClientField is used in every client-side log statement made through grpc_zap. Can be overwritten before initialization.
-//ClientField = zap.String("span.kind", "client")
 )
 
 // UnaryClientInterceptor returns a new unary client interceptor that optionally logs the execution of external gRPC calls.
@@ -42,8 +34,8 @@ func StreamClientInterceptor(logger *zerolog.Logger, opts ...Option) grpc.Stream
 }
 
 func logFinalClientLine(o *options, logger *ctxzr.CtxLogger, startTime time.Time, err error, msg string) {
-	code := o.codeFunc(err)
-	var level = o.levelFunc(code)
+	code  := o.codeFunc(err)
+	level := o.levelFunc(code)
 
 	clientLogger := logger.Logger.WithLevel(level).Err(err)
 	args := make(map[string]interface{})

--- a/logging/zerolog/client_interceptors.go
+++ b/logging/zerolog/client_interceptors.go
@@ -1,0 +1,70 @@
+// Copyright 2017 Michal Witkowski. All Rights Reserved.
+// See LICENSE for licensing terms.
+
+package grpc_zerolog
+
+import (
+	"context"
+	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zerolog/ctxzr"
+	"github.com/rs/zerolog"
+	"google.golang.org/grpc"
+	"path"
+	"time"
+)
+
+var (
+// ClientField is used in every client-side log statement made through grpc_zap. Can be overwritten before initialization.
+//ClientField = zap.String("span.kind", "client")
+)
+
+// UnaryClientInterceptor returns a new unary client interceptor that optionally logs the execution of external gRPC calls.
+func UnaryClientInterceptor(logger *zerolog.Logger, opts ...Option) grpc.UnaryClientInterceptor {
+	o := evaluateClientOpt(opts)
+	return func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+		fields := newClientLoggerFields(ctx, method)
+		startTime := time.Now()
+		err := invoker(ctx, method, req, reply, cc, opts...)
+		logFinalClientLine(o, &ctxzr.CtxLogger{Logger: logger, Fields: fields}, startTime, err, "finished client unary call")
+		return err
+	}
+}
+
+// StreamClientInterceptor returns a new streaming client interceptor that optionally logs the execution of external gRPC calls.
+func StreamClientInterceptor(logger *zerolog.Logger, opts ...Option) grpc.StreamClientInterceptor {
+	o := evaluateClientOpt(opts)
+	return func(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string, streamer grpc.Streamer, opts ...grpc.CallOption) (grpc.ClientStream, error) {
+		fields := newClientLoggerFields(ctx, method)
+		startTime := time.Now()
+		clientStream, err := streamer(ctx, desc, cc, method, opts...)
+		logFinalClientLine(o, &ctxzr.CtxLogger{Logger: logger, Fields: fields}, startTime, err, "finished client streaming call")
+		return clientStream, err
+	}
+}
+
+func logFinalClientLine(o *options, logger *ctxzr.CtxLogger, startTime time.Time, err error, msg string) {
+	code := o.codeFunc(err)
+	var level = o.levelFunc(code)
+
+	clientLogger := logger.Logger.WithLevel(level).Err(err)
+	args := make(map[string]interface{})
+	args["grpc.code"] = code.String()
+
+	for k, v := range logger.Fields {
+		args[k] = v
+	}
+	args["msg"] = msg
+	clientLogger.Fields(args)
+	// Add Duration to Fields and Send
+	o.durationFunc(clientLogger.Fields(args), time.Since(startTime)).Send()
+}
+
+func newClientLoggerFields(ctx context.Context, fullMethodString string) map[string]interface{} {
+	service := path.Dir(fullMethodString)[1:]
+	method := path.Base(fullMethodString)
+	return map[string]interface{}{
+		"system":       "grpc",
+		"span.kind":    "client",
+		"grpc.service": service,
+		"grpc.method":  method,
+	}
+}

--- a/logging/zerolog/client_interceptors_test.go
+++ b/logging/zerolog/client_interceptors_test.go
@@ -1,0 +1,187 @@
+package grpc_zerolog_test
+
+import (
+	grpc_zerolog "github.com/grpc-ecosystem/go-grpc-middleware/logging/zerolog"
+	"github.com/rs/zerolog"
+	"io"
+	"runtime"
+	"strings"
+	"testing"
+
+	pb_testproto "github.com/grpc-ecosystem/go-grpc-middleware/testing/testproto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+)
+
+func customClientCodeToLevel(c codes.Code) zerolog.Level {
+	if c == codes.Unauthenticated {
+		// Make this a special case for tests, and an error.
+		return zerolog.ErrorLevel
+	}
+	return grpc_zerolog.DefaultClientCodeToLevel(c)
+}
+
+func TestZRClientSuite(t *testing.T) {
+	if strings.HasPrefix(runtime.Version(), "go1.7") {
+		t.Skipf("Skipping due to json.RawMessage incompatibility with go1.7")
+		return
+	}
+	opts := []grpc_zerolog.Option{
+		grpc_zerolog.WithLevels(customClientCodeToLevel),
+	}
+	b := newZRBaseSuite(t)
+	zerolog.SetGlobalLevel(zerolog.DebugLevel)
+	b.InterceptorTestSuite.ClientOpts = []grpc.DialOption{
+		grpc.WithUnaryInterceptor(grpc_zerolog.UnaryClientInterceptor(b.logger.Logger, opts...)),
+		grpc.WithStreamInterceptor(grpc_zerolog.StreamClientInterceptor(b.logger.Logger, opts...)),
+	}
+	suite.Run(t, &ZRClientSuite{b})
+}
+
+type ZRClientSuite struct {
+	*ZRBaseSuite
+}
+
+func (s *ZRClientSuite) TestPing() {
+	_, err := s.Client.Ping(s.SimpleCtx(), goodPing)
+	assert.NoError(s.T(), err, "there must be not be an on a successful call")
+
+	msgs := s.getOutputJSONs()
+	require.Len(s.T(), msgs, 1, "one log statement should be logged")
+
+	assert.Equal(s.T(), msgs[0]["grpc.service"], "mwitkow.testproto.TestService", "all lines must contain the correct service name")
+	assert.Equal(s.T(), msgs[0]["grpc.method"], "Ping", "all lines must contain the correct method name")
+	assert.Equal(s.T(), msgs[0]["msg"], "finished client unary call", "handler's message must contain the correct message")
+	assert.Equal(s.T(), msgs[0]["span.kind"], "client", "all lines must contain the kind of call (client)")
+	assert.Equal(s.T(), msgs[0]["level"], "debug", "OK codes must be logged on debug level.")
+
+	assert.Contains(s.T(), msgs[0], "grpc.time_ms", "interceptor log statement should contain execution time (duration in ms)")
+}
+
+func (s *ZRClientSuite) TestPingList() {
+	stream, err := s.Client.PingList(s.SimpleCtx(), goodPing)
+	require.NoError(s.T(), err, "should not fail on establishing the stream")
+	for {
+		_, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		require.NoError(s.T(), err, "reading stream should not fail")
+	}
+
+	msgs := s.getOutputJSONs()
+	require.Len(s.T(), msgs, 1, "one log statement should be logged")
+
+	assert.Equal(s.T(), msgs[0]["grpc.service"], "mwitkow.testproto.TestService", "all lines must contain the correct service name")
+	assert.Equal(s.T(), msgs[0]["grpc.method"], "PingList", "all lines must contain the correct method name")
+	assert.Equal(s.T(), msgs[0]["msg"], "finished client streaming call", "handler's message must contain the correct message")
+	assert.Equal(s.T(), msgs[0]["span.kind"], "client", "all lines must contain the kind of call (client)")
+	assert.Equal(s.T(), msgs[0]["level"], "debug", "OK codes must be logged on debug level.")
+	assert.Contains(s.T(), msgs[0], "grpc.time_ms", "interceptor log statement should contain execution time (duration in ms)")
+}
+
+func (s *ZRClientSuite) TestPingError_WithCustomLevels() {
+	for _, tcase := range []struct {
+		code  codes.Code
+		level zerolog.Level
+		msg   string
+	}{
+		{
+			code:  codes.Internal,
+			level: zerolog.WarnLevel,
+			msg:   "Internal must remap to WarnLevel in DefaultClientCodeToLevel",
+		},
+		{
+			code:  codes.NotFound,
+			level: zerolog.DebugLevel,
+			msg:   "NotFound must remap to DebugLevel in DefaultClientCodeToLevel",
+		},
+		{
+			code:  codes.FailedPrecondition,
+			level: zerolog.DebugLevel,
+			msg:   "FailedPrecondition must remap to DebugLevel in DefaultClientCodeToLevel",
+		},
+		{
+			code:  codes.Unauthenticated,
+			level: zerolog.ErrorLevel,
+			msg:   "Unauthenticated is overwritten to ErrorLevel with customClientCodeToLevel override, which probably didn't work",
+		},
+	} {
+		s.SetupTest()
+		_, err := s.Client.PingError(
+			s.SimpleCtx(),
+			&pb_testproto.PingRequest{Value: "something", ErrorCodeReturned: uint32(tcase.code)})
+
+		assert.Error(s.T(), err, "each call here must return an error")
+
+		msgs := s.getOutputJSONs()
+		require.Len(s.T(), msgs, 1, "only a single log message is printed")
+
+		assert.Equal(s.T(), msgs[0]["grpc.service"], "mwitkow.testproto.TestService", "all lines must contain the correct service name")
+		assert.Equal(s.T(), msgs[0]["grpc.method"], "PingError", "all lines must contain the correct method name")
+		assert.Equal(s.T(), msgs[0]["grpc.code"], tcase.code.String(), "all lines must contain a grpc code")
+		assert.Equal(s.T(), msgs[0]["level"], tcase.level.String(), tcase.msg)
+	}
+}
+
+func TestZRClientOverrideSuite(t *testing.T) {
+	if strings.HasPrefix(runtime.Version(), "go1.7") {
+		t.Skip("Skipping due to json.RawMessage incompatibility with go1.7")
+		return
+	}
+	opts := []grpc_zerolog.Option{
+		grpc_zerolog.WithDurationField(grpc_zerolog.DurationToDurationField),
+	}
+	b := newZRBaseSuite(t)
+	zerolog.SetGlobalLevel(zerolog.DebugLevel)
+	b.InterceptorTestSuite.ClientOpts = []grpc.DialOption{
+		grpc.WithUnaryInterceptor(grpc_zerolog.UnaryClientInterceptor(b.logger.Logger, opts...)),
+		grpc.WithStreamInterceptor(grpc_zerolog.StreamClientInterceptor(b.logger.Logger, opts...)),
+	}
+	suite.Run(t, &ZRClientOverrideSuite{b})
+}
+
+type ZRClientOverrideSuite struct {
+	*ZRBaseSuite
+}
+
+func (s *ZRClientOverrideSuite) TestPing_HasOverrides() {
+	_, err := s.Client.Ping(s.SimpleCtx(), goodPing)
+	assert.NoError(s.T(), err, "there must be not be an on a successful call")
+
+	msgs := s.getOutputJSONs()
+	require.Len(s.T(), msgs, 1, "one log statement should be logged")
+	assert.Equal(s.T(), msgs[0]["grpc.service"], "mwitkow.testproto.TestService", "all lines must contain the correct service name")
+	assert.Equal(s.T(), msgs[0]["grpc.method"], "Ping", "all lines must contain the correct method name")
+	assert.Equal(s.T(), msgs[0]["msg"], "finished client unary call", "handler's message must contain the correct message")
+
+	assert.NotContains(s.T(), msgs[0], "grpc.time_ms", "message must not contain default duration")
+	assert.Contains(s.T(), msgs[0], "grpc.duration", "message must contain overridden duration")
+}
+
+func (s *ZRClientOverrideSuite) TestPingList_HasOverrides() {
+	stream, err := s.Client.PingList(s.SimpleCtx(), goodPing)
+	require.NoError(s.T(), err, "should not fail on establishing the stream")
+	for {
+		_, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		require.NoError(s.T(), err, "reading stream should not fail")
+	}
+
+	msgs := s.getOutputJSONs()
+	require.Len(s.T(), msgs, 1, "one log statement should be logged")
+
+	assert.Equal(s.T(), msgs[0]["grpc.service"], "mwitkow.testproto.TestService", "all lines must contain the correct service name")
+	assert.Equal(s.T(), msgs[0]["grpc.method"], "PingList", "all lines must contain the correct method name")
+	assert.Equal(s.T(), msgs[0]["msg"], "finished client streaming call", "log message must be correct")
+	assert.Equal(s.T(), msgs[0]["span.kind"], "client", "all lines must contain the kind of call (client)")
+	assert.Equal(s.T(), msgs[0]["level"], "debug", "OK codes must be logged on debug level.")
+
+	assert.NotContains(s.T(), msgs[0], "grpc.time_ms", "message must not contain default duration")
+	assert.Contains(s.T(), msgs[0], "grpc.duration", "message must contain overridden duration")
+}

--- a/logging/zerolog/ctxzr/context.go
+++ b/logging/zerolog/ctxzr/context.go
@@ -1,0 +1,80 @@
+package ctxzr
+
+import (
+	"context"
+	grpc_ctxtags "github.com/grpc-ecosystem/go-grpc-middleware/tags"
+	"github.com/rs/zerolog"
+)
+
+type ctxMarker struct{}
+
+type CtxLogger struct {
+	Logger *zerolog.Logger
+	Fields map[string]interface{}
+}
+
+var (
+	ctxMarkerKey = &ctxMarker{}
+	nullLogger   = &zerolog.Logger{}
+)
+
+func MergeFields(mp1 map[string]interface{}, mp2 map[string]interface{}) map[string]interface{} {
+
+	mp3 := make(map[string]interface{}, 0)
+	for k, v := range mp1 {
+		if _, ok := mp1[k]; ok {
+			mp3[k] = v
+		}
+	}
+
+	for k, v := range mp2 {
+		if _, ok := mp2[k]; ok {
+			mp3[k] = v
+		}
+	}
+	return mp3
+}
+
+// AddFields adds fields to the logger.
+func AddFields(ctx context.Context, fields map[string]interface{}) {
+	l, ok := ctx.Value(ctxMarkerKey).(*CtxLogger)
+	if !ok || l == nil {
+		return
+	}
+
+	for k, v := range fields {
+		l.Fields[k] = v
+	}
+
+}
+
+// Extract takes the call-scoped Logger from grpc middleware.
+//
+// It always returns a Logger that has all the grpc_ctxtags updated.
+func Extract(ctx context.Context) *CtxLogger {
+	l, ok := ctx.Value(ctxMarkerKey).(*CtxLogger)
+	if !ok || l == nil {
+		return &CtxLogger{Logger: nullLogger, Fields: make(map[string]interface{}, 0)}
+	}
+	// Add grpc_ctxtags tags metadata until now.
+	fields := TagsToFields(ctx)
+	// Addfields added until now.
+	fields = MergeFields(fields, l.Fields)
+	return &CtxLogger{Logger: l.Logger, Fields: fields}
+}
+
+// TagsToFields transforms the Tags on the supplied context into zap fields.
+func TagsToFields(ctx context.Context) map[string]interface{} {
+	fields := make(map[string]interface{}, 0)
+	tags := grpc_ctxtags.Extract(ctx)
+	for k, v := range tags.Values() {
+		fields[k] = v
+	}
+	return fields
+}
+
+// ToContext adds the zerolog.Logger to the context for extraction later.
+// Returning the new context that has been created.
+func ToContext(ctx context.Context, logger *CtxLogger) context.Context {
+	return context.WithValue(ctx, ctxMarkerKey, logger)
+}

--- a/logging/zerolog/ctxzr/examples_test.go
+++ b/logging/zerolog/ctxzr/examples_test.go
@@ -1,0 +1,23 @@
+package ctxzr_test
+
+import (
+	"context"
+	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zerolog/ctxzr"
+	"github.com/grpc-ecosystem/go-grpc-middleware/tags"
+	pb_testproto "github.com/grpc-ecosystem/go-grpc-middleware/testing/testproto"
+)
+
+// Simple unary handler that adds custom fields to the requests's context. These will be used for all log statements.
+func ExampleExtract_unary() {
+	_ = func(ctx context.Context, ping *pb_testproto.PingRequest) (*pb_testproto.PingResponse, error) {
+		// Add fields the ctxtags of the request which will be added to all extracted loggers.
+		grpc_ctxtags.Extract(ctx).Set("custom_tags.string", "something").Set("custom_tags.int", 1337)
+
+		// Extract a single request-scoped zap.Logger and log messages.
+		l := ctxzr.Extract(ctx)
+		l.Fields["msg1"] = "some ping"
+		l.Fields["msg1"] = "another ping"
+		l.Logger.Info().Fields(l.Fields).Send()
+		return &pb_testproto.PingResponse{Value: ping.Value}, nil
+	}
+}

--- a/logging/zerolog/options.go
+++ b/logging/zerolog/options.go
@@ -1,0 +1,118 @@
+package grpc_zerolog
+
+import (
+	"time"
+
+	grpc_logging "github.com/grpc-ecosystem/go-grpc-middleware/logging"
+	"github.com/rs/zerolog"
+	"google.golang.org/grpc/codes"
+)
+
+var (
+	defaultOptions = &options{
+		//levelFunc: DefaultCodeToLevel
+		shouldLog:    grpc_logging.DefaultDeciderMethod,
+		codeFunc:     grpc_logging.DefaultErrorToCode,
+		durationFunc: DefaultDurationToField,
+	}
+)
+
+type options struct {
+	levelFunc    CodeToLevel
+	shouldLog    grpc_logging.Decider
+	codeFunc     grpc_logging.ErrorToCode
+	durationFunc DurationToField
+}
+
+type Option func(*options)
+
+type CodeToLevel func(code codes.Code) zerolog.Level
+type DurationToField func(logEvent *zerolog.Event, duration time.Duration) *zerolog.Event
+
+func evaluateServerOpt(opts []Option) *options {
+	optCopy := &options{}
+	*optCopy = *defaultOptions
+	optCopy.levelFunc = DefaultCodeToLevel
+	for _, o := range opts {
+		o(optCopy)
+	}
+	return optCopy
+}
+
+func evaluateClientOpt(opts []Option) *options {
+	optCopy := &options{}
+	*optCopy = *defaultOptions
+	optCopy.levelFunc = DefaultClientCodeToLevel
+	for _, o := range opts {
+		o(optCopy)
+	}
+	return optCopy
+}
+
+// WithDecider customizes the function for deciding if the gRPC interceptor logs should log.
+func WithDecider(f grpc_logging.Decider) Option {
+	return func(o *options) {
+		o.shouldLog = f
+	}
+}
+
+// WithLevels customizes the function for mapping gRPC return codes and interceptor log level statements.
+func WithLevels(f CodeToLevel) Option {
+	return func(o *options) {
+		o.levelFunc = f
+	}
+}
+
+// WithCodes customizes the function for mapping errors to error codes.
+func WithCodes(f grpc_logging.ErrorToCode) Option {
+	return func(o *options) {
+		o.codeFunc = f
+	}
+}
+
+// WithDurationField customizes the function for mapping request durations to log fields.
+func WithDurationField(f DurationToField) Option {
+	return func(o *options) {
+		o.durationFunc = f
+	}
+}
+
+// DefaultCodeToLevel is the default implementation of gRPC return codes and interceptor log level for server side.
+func DefaultCodeToLevel(code codes.Code) zerolog.Level {
+	switch code {
+	case codes.OK, codes.Canceled, codes.InvalidArgument, codes.NotFound, codes.AlreadyExists, codes.Unauthenticated:
+		return zerolog.InfoLevel
+	case codes.DeadlineExceeded, codes.PermissionDenied, codes.ResourceExhausted, codes.FailedPrecondition, codes.Aborted, codes.OutOfRange, codes.Unavailable:
+		return zerolog.WarnLevel
+	case codes.Unknown, codes.Unimplemented, codes.Internal, codes.DataLoss:
+		return zerolog.ErrorLevel
+	default:
+		return zerolog.ErrorLevel
+	}
+}
+
+func DefaultClientCodeToLevel(code codes.Code) zerolog.Level {
+	switch code {
+	case codes.OK, codes.Canceled, codes.InvalidArgument, codes.NotFound, codes.AlreadyExists, codes.ResourceExhausted, codes.FailedPrecondition, codes.Aborted, codes.OutOfRange:
+		return zerolog.DebugLevel
+	case codes.Unknown, codes.DeadlineExceeded, codes.PermissionDenied, codes.Unauthenticated:
+		return zerolog.InfoLevel
+	case codes.Unimplemented, codes.Internal, codes.Unavailable, codes.DataLoss:
+		return zerolog.WarnLevel
+	default:
+		return zerolog.InfoLevel
+	}
+}
+
+var DefaultDurationToField = DurationToTimeMillisField
+
+// DurationToTimeMillisField converts the duration to milliseconds and uses the key `grpc.time_ms`.
+func DurationToTimeMillisField(logEvent *zerolog.Event, duration time.Duration) *zerolog.Event {
+	return logEvent.Dur("grpc.time_ms", duration)
+}
+
+// DurationToDurationField uses a Duration field to log the request duration
+// and leaves it up to Zap's encoder settings to determine how that is output.
+func DurationToDurationField(logEvent *zerolog.Event, duration time.Duration) *zerolog.Event {
+	return logEvent.Dur("grpc.duration", duration)
+}

--- a/logging/zerolog/payload_interceptors.go
+++ b/logging/zerolog/payload_interceptors.go
@@ -1,16 +1,15 @@
-package grpc_zap
+package grpc_zerolog
 
 import (
 	"bytes"
-	"context"
 	"fmt"
+	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zerolog/ctxzr"
 
+	"context"
 	"github.com/golang/protobuf/jsonpb"
 	"github.com/golang/protobuf/proto"
-	"github.com/grpc-ecosystem/go-grpc-middleware/logging"
-	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
-	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
+	grpc_logging "github.com/grpc-ecosystem/go-grpc-middleware/logging"
+	"github.com/rs/zerolog"
 	"google.golang.org/grpc"
 )
 
@@ -21,19 +20,20 @@ var (
 
 // PayloadUnaryServerInterceptor returns a new unary server interceptors that logs the payloads of requests.
 //
-// This *only* works when placed *after* the `grpc_zap.UnaryServerInterceptor`. However, the logging can be done to a
+// This *only* works when placed *after* the `grpc_zerolog.UnaryServerInterceptor`. However, the logging can be done to a
 // separate instance of the logger.
-func PayloadUnaryServerInterceptor(logger *zap.Logger, decider grpc_logging.ServerPayloadLoggingDecider) grpc.UnaryServerInterceptor {
+func PayloadUnaryServerInterceptor(logger *zerolog.Logger, decider grpc_logging.ServerPayloadLoggingDecider) grpc.UnaryServerInterceptor {
 	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
 		if !decider(ctx, info.FullMethod, info.Server) {
 			return handler(ctx, req)
 		}
-		// Use the provided zap.Logger for logging but use the fields from context.
-		logEntry := logger.With(append(serverCallFields(info.FullMethod), ctxzap.TagsToFields(ctx)...)...)
-		logProtoMessageAsJson(logEntry, req, "grpc.request.content", "server request payload logged as grpc.request.content field")
+		// Use the provided log.Logger for logging but use the fields from context.
+		resLogger := ctxzr.CtxLogger{Logger: logger, Fields: ctxzr.MergeFields(serverCallFields(info.FullMethod), ctxzr.TagsToFields(ctx))}
+
+		logProtoMessageAsJson(&resLogger, req, "grpc.request.content", "server request payload logged as grpc.request.content field")
 		resp, err := handler(ctx, req)
 		if err == nil {
-			logProtoMessageAsJson(logEntry, resp, "grpc.response.content", "server response payload logged as grpc.response.content field")
+			logProtoMessageAsJson(&resLogger, resp, "grpc.response.content", "server response payload logged as grpc.response.content field")
 		}
 		return resp, err
 	}
@@ -41,51 +41,52 @@ func PayloadUnaryServerInterceptor(logger *zap.Logger, decider grpc_logging.Serv
 
 // PayloadStreamServerInterceptor returns a new server server interceptors that logs the payloads of requests.
 //
-// This *only* works when placed *after* the `grpc_zap.StreamServerInterceptor`. However, the logging can be done to a
+// This *only* works when placed *after* the `grpc_zerolog.StreamServerInterceptor`. However, the logging can be done to a
 // separate instance of the logger.
-func PayloadStreamServerInterceptor(logger *zap.Logger, decider grpc_logging.ServerPayloadLoggingDecider) grpc.StreamServerInterceptor {
+func PayloadStreamServerInterceptor(logger *zerolog.Logger, decider grpc_logging.ServerPayloadLoggingDecider) grpc.StreamServerInterceptor {
 	return func(srv interface{}, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
 		if !decider(stream.Context(), info.FullMethod, srv) {
 			return handler(srv, stream)
 		}
-		logEntry := logger.With(append(serverCallFields(info.FullMethod), ctxzap.TagsToFields(stream.Context())...)...)
-		newStream := &loggingServerStream{ServerStream: stream, logger: logEntry}
+		logEntry := ctxzr.CtxLogger{Logger: logger, Fields: ctxzr.MergeFields(serverCallFields(info.FullMethod), ctxzr.TagsToFields(stream.Context()))}
+
+		newStream := &loggingServerStream{ServerStream: stream, logger: &logEntry}
 		return handler(srv, newStream)
 	}
 }
 
 // PayloadUnaryClientInterceptor returns a new unary client interceptor that logs the paylods of requests and responses.
-func PayloadUnaryClientInterceptor(logger *zap.Logger, decider grpc_logging.ClientPayloadLoggingDecider) grpc.UnaryClientInterceptor {
+func PayloadUnaryClientInterceptor(logger *zerolog.Logger, decider grpc_logging.ClientPayloadLoggingDecider) grpc.UnaryClientInterceptor {
 	return func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
 		if !decider(ctx, method) {
 			return invoker(ctx, method, req, reply, cc, opts...)
 		}
-		logEntry := logger.With(newClientLoggerFields(ctx, method)...)
-		logProtoMessageAsJson(logEntry, req, "grpc.request.content", "client request payload logged as grpc.request.content")
+		logEntry := ctxzr.CtxLogger{Logger: logger, Fields: newClientLoggerFields(ctx, method)}
+		logProtoMessageAsJson(&logEntry, req, "grpc.request.content", "client request payload logged as grpc.request.content")
 		err := invoker(ctx, method, req, reply, cc, opts...)
 		if err == nil {
-			logProtoMessageAsJson(logEntry, reply, "grpc.response.content", "client response payload logged as grpc.response.content")
+			logProtoMessageAsJson(&logEntry, reply, "grpc.response.content", "client response payload logged as grpc.response.content")
 		}
 		return err
 	}
 }
 
 // PayloadStreamClientInterceptor returns a new streaming client interceptor that logs the paylods of requests and responses.
-func PayloadStreamClientInterceptor(logger *zap.Logger, decider grpc_logging.ClientPayloadLoggingDecider) grpc.StreamClientInterceptor {
+func PayloadStreamClientInterceptor(logger *zerolog.Logger, decider grpc_logging.ClientPayloadLoggingDecider) grpc.StreamClientInterceptor {
 	return func(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string, streamer grpc.Streamer, opts ...grpc.CallOption) (grpc.ClientStream, error) {
 		if !decider(ctx, method) {
 			return streamer(ctx, desc, cc, method, opts...)
 		}
-		logEntry := logger.With(newClientLoggerFields(ctx, method)...)
+		logEntry := ctxzr.CtxLogger{Logger: logger, Fields: newClientLoggerFields(ctx, method)}
 		clientStream, err := streamer(ctx, desc, cc, method, opts...)
-		newStream := &loggingClientStream{ClientStream: clientStream, logger: logEntry}
+		newStream := &loggingClientStream{ClientStream: clientStream, logger: &logEntry}
 		return newStream, err
 	}
 }
 
 type loggingClientStream struct {
 	grpc.ClientStream
-	logger *zap.Logger
+	logger *ctxzr.CtxLogger
 }
 
 func (l *loggingClientStream) SendMsg(m interface{}) error {
@@ -106,7 +107,7 @@ func (l *loggingClientStream) RecvMsg(m interface{}) error {
 
 type loggingServerStream struct {
 	grpc.ServerStream
-	logger *zap.Logger
+	logger *ctxzr.CtxLogger
 }
 
 func (l *loggingServerStream) SendMsg(m interface{}) error {
@@ -125,19 +126,19 @@ func (l *loggingServerStream) RecvMsg(m interface{}) error {
 	return err
 }
 
-func logProtoMessageAsJson(logger *zap.Logger, pbMsg interface{}, key string, msg string) {
+func logProtoMessageAsJson(logger *ctxzr.CtxLogger, pbMsg interface{}, key string, msg string) {
 	if p, ok := pbMsg.(proto.Message); ok {
-		logger.Check(zapcore.InfoLevel, msg).Write(zap.Object(key, &jsonpbObjectMarshaler{pb: p}))
+		payload, err := (&jsonpbObjectMarshaler{pb: p}).MarshalJSON()
+		if err != nil {
+			logger.Logger.Err(err).Fields(logger.Fields).RawJSON(key, payload).Msg(msg)
+		} else {
+			logger.Logger.Info().Fields(logger.Fields).RawJSON(key, payload).Msg(msg)
+		}
 	}
 }
 
 type jsonpbObjectMarshaler struct {
 	pb proto.Message
-}
-
-func (j *jsonpbObjectMarshaler) MarshalLogObject(e zapcore.ObjectEncoder) error {
-	// ZAP jsonEncoder deals with AddReflect by using json.MarshalObject. The same thing applies for consoleEncoder.
-	return e.AddReflected("msg", j)
 }
 
 func (j *jsonpbObjectMarshaler) MarshalJSON() ([]byte, error) {

--- a/logging/zerolog/payload_interceptors_test.go
+++ b/logging/zerolog/payload_interceptors_test.go
@@ -1,0 +1,130 @@
+package grpc_zerolog_test
+
+import (
+	"github.com/rs/zerolog"
+	"io"
+	"runtime"
+	"strings"
+	"testing"
+
+	"context"
+	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
+	grpc_zerolog "github.com/grpc-ecosystem/go-grpc-middleware/logging/zerolog"
+	grpc_ctxtags "github.com/grpc-ecosystem/go-grpc-middleware/tags"
+	pb_testproto "github.com/grpc-ecosystem/go-grpc-middleware/testing/testproto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	"google.golang.org/grpc"
+)
+
+func TestZRPayloadSuite(t *testing.T) {
+	if strings.HasPrefix(runtime.Version(), "go1.7") {
+		t.Skipf("Skipping due to json.RawMessage incompatibility with go1.7")
+		return
+	}
+
+	alwaysLoggingDeciderServer := func(ctx context.Context, fullMethodName string, servingObject interface{}) bool { return true }
+	alwaysLoggingDeciderClient := func(ctx context.Context, fullMethodName string) bool { return true }
+
+	b := newZRBaseSuite(t)
+	b.InterceptorTestSuite.ClientOpts = []grpc.DialOption{
+		grpc.WithUnaryInterceptor(grpc_zerolog.PayloadUnaryClientInterceptor(b.logger.Logger, alwaysLoggingDeciderClient)),
+		grpc.WithStreamInterceptor(grpc_zerolog.PayloadStreamClientInterceptor(b.logger.Logger, alwaysLoggingDeciderClient)),
+	}
+	noOpLogger := zerolog.New(zerolog.Nop())
+	b.InterceptorTestSuite.ServerOpts = []grpc.ServerOption{
+		grpc_middleware.WithStreamServerChain(
+			grpc_ctxtags.StreamServerInterceptor(grpc_ctxtags.WithFieldExtractor(grpc_ctxtags.CodeGenRequestFieldExtractor)),
+			grpc_zerolog.StreamServerInterceptor(&noOpLogger),
+			grpc_zerolog.PayloadStreamServerInterceptor(b.logger.Logger, alwaysLoggingDeciderServer)),
+		grpc_middleware.WithUnaryServerChain(
+			grpc_ctxtags.UnaryServerInterceptor(grpc_ctxtags.WithFieldExtractor(grpc_ctxtags.CodeGenRequestFieldExtractor)),
+			grpc_zerolog.UnaryServerInterceptor(&noOpLogger),
+			grpc_zerolog.PayloadUnaryServerInterceptor(b.logger.Logger, alwaysLoggingDeciderServer)),
+	}
+	suite.Run(t, &ZRPayloadSuite{b})
+}
+
+type ZRPayloadSuite struct {
+	*ZRBaseSuite
+}
+
+func (s *ZRPayloadSuite) getServerAndClientMessages(expectedServer int, expectedClient int) (serverMsgs []map[string]interface{}, clientMsgs []map[string]interface{}) {
+	msgs := s.getOutputJSONs()
+	for _, m := range msgs {
+		if m["span.kind"] == "server" {
+			serverMsgs = append(serverMsgs, m)
+		} else if m["span.kind"] == "client" {
+			clientMsgs = append(clientMsgs, m)
+		}
+	}
+	require.Len(s.T(), serverMsgs, expectedServer, "must match expected number of server log messages")
+	require.Len(s.T(), clientMsgs, expectedClient, "must match expected number of client log messages")
+	return serverMsgs, clientMsgs
+}
+
+func (s *ZRPayloadSuite) TestPing_LogsBothRequestAndResponse() {
+	_, err := s.Client.Ping(s.SimpleCtx(), goodPing)
+
+	require.NoError(s.T(), err, "there must be not be an error on a successful call")
+	serverMsgs, clientMsgs := s.getServerAndClientMessages(2, 2)
+	for _, m := range append(serverMsgs, clientMsgs...) {
+		assert.Equal(s.T(), m["grpc.service"], "mwitkow.testproto.TestService", "all lines must contain service name")
+		assert.Equal(s.T(), m["grpc.method"], "Ping", "all lines must contain method name")
+		assert.Equal(s.T(), m["level"], "info", "all payloads must be logged on info level")
+	}
+
+	serverReq, serverResp := serverMsgs[0], serverMsgs[1]
+	clientReq, clientResp := clientMsgs[0], clientMsgs[1]
+	s.T().Log(clientReq)
+	assert.Contains(s.T(), clientReq, "grpc.request.content", "request payload must be logged in a structured way")
+	assert.Contains(s.T(), serverReq, "grpc.request.content", "request payload must be logged in a structured way")
+	assert.Contains(s.T(), clientResp, "grpc.response.content", "response payload must be logged in a structured way")
+	assert.Contains(s.T(), serverResp, "grpc.response.content", "response payload must be logged in a structured way")
+}
+
+func (s *ZRPayloadSuite) TestPingError_LogsOnlyRequestsOnError() {
+	_, err := s.Client.PingError(s.SimpleCtx(), &pb_testproto.PingRequest{Value: "something", ErrorCodeReturned: uint32(4)})
+
+	require.Error(s.T(), err, "there must be an error on an unsuccessful call")
+	serverMsgs, clientMsgs := s.getServerAndClientMessages(1, 1)
+	for _, m := range append(serverMsgs, clientMsgs...) {
+		assert.Equal(s.T(), m["grpc.service"], "mwitkow.testproto.TestService", "all lines must contain service name")
+		assert.Equal(s.T(), m["grpc.method"], "PingError", "all lines must contain method name")
+		assert.Equal(s.T(), m["level"], "info", "must be logged at the info level")
+	}
+
+	assert.Contains(s.T(), clientMsgs[0], "grpc.request.content", "request payload must be logged in a structured way")
+	assert.Contains(s.T(), serverMsgs[0], "grpc.request.content", "request payload must be logged in a structured way")
+}
+
+func (s *ZRPayloadSuite) TestPingStream_LogsAllRequestsAndResponses() {
+	messagesExpected := 20
+	stream, err := s.Client.PingStream(s.SimpleCtx())
+
+	require.NoError(s.T(), err, "no error on stream creation")
+	for i := 0; i < messagesExpected; i++ {
+		require.NoError(s.T(), stream.Send(goodPing), "sending must succeed")
+	}
+	require.NoError(s.T(), stream.CloseSend(), "no error on send stream")
+
+	for {
+		pong := &pb_testproto.PingResponse{}
+		err := stream.RecvMsg(pong)
+		if err == io.EOF {
+			break
+		}
+		require.NoError(s.T(), err, "no error on receive")
+	}
+
+	serverMsgs, clientMsgs := s.getServerAndClientMessages(2*messagesExpected, 2*messagesExpected)
+	for _, m := range append(serverMsgs, clientMsgs...) {
+		assert.Equal(s.T(), m["grpc.service"], "mwitkow.testproto.TestService", "all lines must contain service name")
+		assert.Equal(s.T(), m["grpc.method"], "PingStream", "all lines must contain method name")
+		assert.Equal(s.T(), m["level"], "info", "all lines must logged at info level")
+
+		content := m["grpc.request.content"] != nil || m["grpc.response.content"] != nil
+		assert.True(s.T(), content, "all messages must contain payloads")
+	}
+}

--- a/logging/zerolog/server_interceptors.go
+++ b/logging/zerolog/server_interceptors.go
@@ -1,0 +1,105 @@
+package grpc_zerolog
+
+import (
+	"github.com/rs/zerolog"
+	"path"
+	"time"
+
+	"context"
+	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
+	//"github.com/grpc-ecosystem/go-grpc-middleware/logging/zerolog/ctxzr"
+	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zerolog/ctxzr"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+)
+
+var (
+	// SystemField is used in every log statement made through grpc_zap. Can be overwritten before any initialization code.
+	SystemField = "grpc"
+	// ServerField is used in every server-side log statement made through grpc_zap.Can be overwritten before initialization.
+	ServerField = "server"
+)
+
+// UnaryServerInterceptor returns a new unary server interceptors that adds zap.Logger to the context.
+func UnaryServerInterceptor(logger *zerolog.Logger, opts ...Option) grpc.UnaryServerInterceptor {
+	o := evaluateServerOpt(opts)
+	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+		startTime := time.Now()
+		newCtx := injectLogger(ctx, logger, info.FullMethod, startTime)
+
+		resp, err := handler(newCtx, req)
+		if !o.shouldLog(info.FullMethod, err) {
+			return resp, err
+		}
+
+		code := o.codeFunc(err)
+		logCall(newCtx, o, "finished unary call with code "+code.String(), code, startTime)
+
+		return resp, err
+	}
+}
+
+func StreamServerInterceptor(logger *zerolog.Logger, opts ...Option) grpc.StreamServerInterceptor {
+	o := evaluateServerOpt(opts)
+	return func(srv interface{}, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		startTime := time.Now()
+		newCtx := injectLogger(stream.Context(), logger, info.FullMethod, startTime)
+
+		wrapped := grpc_middleware.WrapServerStream(stream)
+		wrapped.WrappedContext = newCtx
+
+		err := handler(srv, wrapped)
+		if !o.shouldLog(info.FullMethod, err) {
+			return err
+		}
+
+		code := o.codeFunc(err)
+		logCall(newCtx, o, "finished streaming call with code "+code.String(), code, startTime)
+
+		return err
+	}
+}
+
+func injectLogger(ctx context.Context, logger *zerolog.Logger, fullMethodString string, start time.Time) context.Context {
+	f := ctxzr.TagsToFields(ctx)
+	f["grpc.start_time"] = start.Format(time.RFC3339)
+	if d, ok := ctx.Deadline(); ok {
+		f["grpc.request.deadline"] = d.Format(time.RFC3339)
+	}
+	for k, v := range serverCallFields(fullMethodString) {
+		f[k] = v
+	}
+
+	var injectLog = ctxzr.CtxLogger{Logger: logger, Fields: f}
+
+	return ctxzr.ToContext(ctx, &injectLog)
+}
+
+func serverCallFields(fullMethodString string) map[string]interface{} {
+	service := path.Dir(fullMethodString)[1:]
+	method := path.Base(fullMethodString)
+	return map[string]interface{}{
+		"system":       SystemField,
+		"span.kind":    ServerField,
+		"grpc.service": service,
+		"grpc.method":  method,
+	}
+}
+
+func logCall(ctx context.Context, options *options, msg string, code codes.Code, startTime time.Time) {
+
+	extractedLogger := ctxzr.Extract(ctx)
+
+	var level = options.levelFunc(code)
+	logger := extractedLogger.Logger.WithLevel(level)
+
+	args := make(map[string]interface{}, 0)
+	args["grpc.code"] = code.String()
+
+	for k, v := range extractedLogger.Fields {
+		args[k] = v
+	}
+	args["msg"] = msg
+
+	options.durationFunc(logger.Fields(args), time.Since(startTime)).Send()
+}

--- a/logging/zerolog/server_interceptors_test.go
+++ b/logging/zerolog/server_interceptors_test.go
@@ -1,0 +1,319 @@
+package grpc_zerolog_test
+
+import (
+	grpc_zerolog "github.com/grpc-ecosystem/go-grpc-middleware/logging/zerolog"
+	"io"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
+	grpc_ctxtags "github.com/grpc-ecosystem/go-grpc-middleware/tags"
+	pb_testproto "github.com/grpc-ecosystem/go-grpc-middleware/testing/testproto"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+)
+
+func customCodeToLevel(c codes.Code) zerolog.Level {
+	if c == codes.Unauthenticated {
+		// Make this a special case for tests, and an error.
+		return zerolog.ErrorLevel
+	}
+	return grpc_zerolog.DefaultCodeToLevel(c)
+}
+
+func TestZRLoggingSuite(t *testing.T) {
+	if strings.HasPrefix(runtime.Version(), "go1.7") {
+		t.Skipf("Skipping due to json.RawMessage incompatibility with go1.7")
+		return
+	}
+	opts := []grpc_zerolog.Option{
+		grpc_zerolog.WithLevels(customCodeToLevel),
+	}
+	b := newZRBaseSuite(t)
+	b.InterceptorTestSuite.ServerOpts = []grpc.ServerOption{
+		grpc_middleware.WithStreamServerChain(
+			grpc_ctxtags.StreamServerInterceptor(grpc_ctxtags.WithFieldExtractor(grpc_ctxtags.CodeGenRequestFieldExtractor)),
+			grpc_zerolog.StreamServerInterceptor(b.logger.Logger, opts...)),
+		grpc_middleware.WithUnaryServerChain(
+			grpc_ctxtags.UnaryServerInterceptor(grpc_ctxtags.WithFieldExtractor(grpc_ctxtags.CodeGenRequestFieldExtractor)),
+			grpc_zerolog.UnaryServerInterceptor(b.logger.Logger, opts...)),
+	}
+	suite.Run(t, &ZRServerSuite{b})
+}
+
+type ZRServerSuite struct {
+	*ZRBaseSuite
+}
+
+func (s *ZRServerSuite) TestPing_WithCustomTags() {
+	deadline := time.Now().Add(3 * time.Second)
+	_, err := s.Client.Ping(s.DeadlineCtx(deadline), goodPing)
+	require.NoError(s.T(), err, "there must be not be an error on a successful call")
+
+	msgs := s.getOutputJSONs()
+	require.Len(s.T(), msgs, 2, "two log statements should be logged")
+	for _, m := range msgs {
+		assert.Equal(s.T(), m["grpc.service"], "mwitkow.testproto.TestService", "all lines must contain service name")
+		assert.Equal(s.T(), m["grpc.method"], "Ping", "all lines must contain method name")
+		assert.Equal(s.T(), m["span.kind"], "server", "all lines must contain the kind of call (server)")
+		assert.Equal(s.T(), m["custom_tags.string"], "something", "all lines must contain `custom_tags.string`")
+		assert.Equal(s.T(), m["grpc.request.value"], "something", "all lines must contain fields extracted")
+		assert.Equal(s.T(), m["custom_field"], "custom_value", "all lines must contain `custom_field`")
+
+		assert.Contains(s.T(), m, "custom_tags.int", "all lines must contain `custom_tags.int`")
+		require.Contains(s.T(), m, "grpc.start_time", "all lines must contain the start time")
+		_, err := time.Parse(time.RFC3339, m["grpc.start_time"].(string))
+		assert.NoError(s.T(), err, "should be able to parse start time as RFC3339")
+
+		require.Contains(s.T(), m, "grpc.request.deadline", "all lines must contain the deadline of the call")
+		_, err = time.Parse(time.RFC3339, m["grpc.request.deadline"].(string))
+		require.NoError(s.T(), err, "should be able to parse deadline as RFC3339")
+		assert.Equal(s.T(), m["grpc.request.deadline"], deadline.Format(time.RFC3339), "should have the same deadline that was set by the caller")
+	}
+
+	assert.Equal(s.T(), msgs[0]["msg"], "some ping", "handler's message must contain user message")
+
+	assert.Equal(s.T(), msgs[1]["msg"], "finished unary call with code OK", "handler's message must contain user message")
+	assert.Equal(s.T(), msgs[1]["level"], "info", "must be logged at info level")
+	assert.Contains(s.T(), msgs[1], "grpc.time_ms", "interceptor log statement should contain execution time")
+}
+
+func (s *ZRServerSuite) TestPingError_WithCustomLevels() {
+	for _, tcase := range []struct {
+		code  codes.Code
+		level zerolog.Level
+		msg   string
+	}{
+		{
+			code:  codes.Internal,
+			level: zerolog.ErrorLevel,
+			msg:   "Internal must remap to ErrorLevel in DefaultCodeToLevel",
+		},
+		{
+			code:  codes.NotFound,
+			level: zerolog.InfoLevel,
+			msg:   "NotFound must remap to InfoLevel in DefaultCodeToLevel",
+		},
+		{
+			code:  codes.FailedPrecondition,
+			level: zerolog.WarnLevel,
+			msg:   "FailedPrecondition must remap to WarnLevel in DefaultCodeToLevel",
+		},
+		{
+			code:  codes.Unauthenticated,
+			level: zerolog.ErrorLevel,
+			msg:   "Unauthenticated is overwritten to PanicLevel with customCodeToLevel override, which probably didn't work",
+		},
+	} {
+		s.buffer.Reset()
+		_, err := s.Client.PingError(
+			s.SimpleCtx(),
+			&pb_testproto.PingRequest{Value: "something", ErrorCodeReturned: uint32(tcase.code)})
+		require.Error(s.T(), err, "each call here must return an error")
+
+		msgs := s.getOutputJSONs()
+		require.Len(s.T(), msgs, 1, "only the interceptor log message is printed in PingErr")
+
+		m := msgs[0]
+		assert.Equal(s.T(), m["grpc.service"], "mwitkow.testproto.TestService", "all lines must contain service name")
+		assert.Equal(s.T(), m["grpc.method"], "PingError", "all lines must contain method name")
+		assert.Equal(s.T(), m["grpc.code"], tcase.code.String(), "all lines have the correct gRPC code")
+		assert.Equal(s.T(), m["level"], tcase.level.String(), tcase.msg)
+		assert.Equal(s.T(), m["msg"], "finished unary call with code "+tcase.code.String(), "needs the correct end message")
+
+		require.Contains(s.T(), m, "grpc.start_time", "all lines must contain the start time")
+		_, err = time.Parse(time.RFC3339, m["grpc.start_time"].(string))
+		assert.NoError(s.T(), err, "should be able to parse start time as RFC3339")
+	}
+}
+
+func (s *ZRServerSuite) TestPingList_WithCustomTags() {
+	stream, err := s.Client.PingList(s.SimpleCtx(), goodPing)
+	require.NoError(s.T(), err, "should not fail on establishing the stream")
+	for {
+		_, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		require.NoError(s.T(), err, "reading stream should not fail")
+	}
+	msgs := s.getOutputJSONs()
+	require.Len(s.T(), msgs, 2, "two log statements should be logged")
+
+	for _, m := range msgs {
+		assert.Equal(s.T(), m["grpc.service"], "mwitkow.testproto.TestService", "all lines must contain service name")
+		assert.Equal(s.T(), m["grpc.method"], "PingList", "all lines must contain method name")
+		assert.Equal(s.T(), m["span.kind"], "server", "all lines must contain the kind of call (server)")
+		assert.Equal(s.T(), m["custom_tags.string"], "something", "all lines must contain `custom_tags.string` set by AddFields")
+		assert.Equal(s.T(), m["grpc.request.value"], "something", "all lines must contain fields extracted from goodPing because of test.manual_extractfields.pb")
+
+		assert.Contains(s.T(), m, "custom_tags.int", "all lines must contain `custom_tags.int` set by AddFields")
+		require.Contains(s.T(), m, "grpc.start_time", "all lines must contain the start time")
+		_, err := time.Parse(time.RFC3339, m["grpc.start_time"].(string))
+		assert.NoError(s.T(), err, "should be able to parse start time as RFC3339")
+	}
+
+	assert.Equal(s.T(), msgs[0]["msg"], "some pinglist", "handler's message must contain user message")
+
+	assert.Equal(s.T(), msgs[1]["msg"], "finished streaming call with code OK", "handler's message must contain user message")
+	assert.Equal(s.T(), msgs[1]["level"], "info", "OK codes must be logged on info level.")
+	assert.Contains(s.T(), msgs[1], "grpc.time_ms", "interceptor log statement should contain execution time")
+}
+
+func TestZRLoggingOverrideSuite(t *testing.T) {
+	if strings.HasPrefix(runtime.Version(), "go1.7") {
+		t.Skip("Skipping due to json.RawMessage incompatibility with go1.7")
+		return
+	}
+	opts := []grpc_zerolog.Option{
+		grpc_zerolog.WithDurationField(grpc_zerolog.DurationToDurationField),
+	}
+	b := newZRBaseSuite(t)
+	b.InterceptorTestSuite.ServerOpts = []grpc.ServerOption{
+		grpc_middleware.WithStreamServerChain(
+			grpc_ctxtags.StreamServerInterceptor(),
+			grpc_zerolog.StreamServerInterceptor(b.logger.Logger, opts...)),
+		grpc_middleware.WithUnaryServerChain(
+			grpc_ctxtags.UnaryServerInterceptor(),
+			grpc_zerolog.UnaryServerInterceptor(b.logger.Logger, opts...)),
+	}
+	suite.Run(t, &ZRServerOverrideSuite{b})
+}
+
+type ZRServerOverrideSuite struct {
+	*ZRBaseSuite
+}
+
+func (s *ZRServerOverrideSuite) TestPing_HasOverriddenDuration() {
+	_, err := s.Client.Ping(s.SimpleCtx(), goodPing)
+	require.NoError(s.T(), err, "there must be not be an error on a successful call")
+	msgs := s.getOutputJSONs()
+	require.Len(s.T(), msgs, 2, "two log statements should be logged")
+
+	for _, m := range msgs {
+		assert.Equal(s.T(), m["grpc.service"], "mwitkow.testproto.TestService", "all lines must contain service name")
+		assert.Equal(s.T(), m["grpc.method"], "Ping", "all lines must contain method name")
+	}
+	assert.Equal(s.T(), msgs[0]["msg"], "some ping", "handler's message must contain user message")
+	assert.NotContains(s.T(), msgs[0], "grpc.time_ms", "handler's message must not contain default duration")
+	assert.NotContains(s.T(), msgs[0], "grpc.duration", "handler's message must not contain overridden duration")
+
+	assert.Equal(s.T(), msgs[1]["msg"], "finished unary call with code OK", "handler's message must contain user message")
+	assert.Equal(s.T(), msgs[1]["level"], "info", "OK error codes must be logged on info level.")
+	assert.NotContains(s.T(), msgs[1], "grpc.time_ms", "handler's message must not contain default duration")
+	assert.Contains(s.T(), msgs[1], "grpc.duration", "handler's message must contain overridden duration")
+}
+
+func (s *ZRServerOverrideSuite) TestPingList_HasOverriddenDuration() {
+	stream, err := s.Client.PingList(s.SimpleCtx(), goodPing)
+	require.NoError(s.T(), err, "should not fail on establishing the stream")
+	for {
+		_, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		require.NoError(s.T(), err, "reading stream should not fail")
+	}
+	msgs := s.getOutputJSONs()
+	require.Len(s.T(), msgs, 2, "two log statements should be logged")
+	for _, m := range msgs {
+		s.T()
+		assert.Equal(s.T(), m["grpc.service"], "mwitkow.testproto.TestService", "all lines must contain service name")
+		assert.Equal(s.T(), m["grpc.method"], "PingList", "all lines must contain method name")
+	}
+
+	assert.Equal(s.T(), msgs[0]["msg"], "some pinglist", "handler's message must contain user message")
+	assert.NotContains(s.T(), msgs[0], "grpc.time_ms", "handler's message must not contain default duration")
+	assert.NotContains(s.T(), msgs[0], "grpc.duration", "handler's message must not contain overridden duration")
+
+	assert.Equal(s.T(), msgs[1]["msg"], "finished streaming call with code OK", "handler's message must contain user message")
+	assert.Equal(s.T(), msgs[1]["level"], "info", "OK error codes must be logged on info level.")
+	assert.NotContains(s.T(), msgs[1], "grpc.time_ms", "handler's message must not contain default duration")
+	assert.Contains(s.T(), msgs[1], "grpc.duration", "handler's message must contain overridden duration")
+}
+
+func TestZRServerOverrideSuppressedSuite(t *testing.T) {
+	if strings.HasPrefix(runtime.Version(), "go1.7") {
+		t.Skip("Skipping due to json.RawMessage incompatibility with go1.7")
+		return
+	}
+	opts := []grpc_zerolog.Option{
+		grpc_zerolog.WithDecider(func(method string, err error) bool {
+			if err != nil && method == "/mwitkow.testproto.TestService/PingError" {
+				return true
+			}
+			return false
+		}),
+	}
+	b := newZRBaseSuite(t)
+	b.InterceptorTestSuite.ServerOpts = []grpc.ServerOption{
+		grpc_middleware.WithStreamServerChain(
+			grpc_ctxtags.StreamServerInterceptor(),
+			grpc_zerolog.StreamServerInterceptor(b.logger.Logger, opts...)),
+		grpc_middleware.WithUnaryServerChain(
+			grpc_ctxtags.UnaryServerInterceptor(),
+			grpc_zerolog.UnaryServerInterceptor(b.logger.Logger, opts...)),
+	}
+	suite.Run(t, &ZRServerOverridenDeciderSuite{b})
+}
+
+type ZRServerOverridenDeciderSuite struct {
+	*ZRBaseSuite
+}
+
+func (s *ZRServerOverridenDeciderSuite) TestPing_HasOverriddenDecider() {
+	_, err := s.Client.Ping(s.SimpleCtx(), goodPing)
+	require.NoError(s.T(), err, "there must be not be an error on a successful call")
+	msgs := s.getOutputJSONs()
+	require.Len(s.T(), msgs, 1, "single log statements should be logged")
+
+	assert.Equal(s.T(), msgs[0]["grpc.service"], "mwitkow.testproto.TestService", "all lines must contain service name")
+	assert.Equal(s.T(), msgs[0]["grpc.method"], "Ping", "all lines must contain method name")
+	assert.Equal(s.T(), msgs[0]["msg"], "some ping", "handler's message must contain user message")
+}
+
+func (s *ZRServerOverridenDeciderSuite) TestPingError_HasOverriddenDecider() {
+	code := codes.NotFound
+	level := zerolog.InfoLevel
+	msg := "NotFound must remap to InfoLevel in DefaultCodeToLevel"
+
+	s.buffer.Reset()
+	_, err := s.Client.PingError(
+		s.SimpleCtx(),
+		&pb_testproto.PingRequest{Value: "something", ErrorCodeReturned: uint32(code)})
+	require.Error(s.T(), err, "each call here must return an error")
+	msgs := s.getOutputJSONs()
+	require.Len(s.T(), msgs, 1, "only the interceptor log message is printed in PingErr")
+	m := msgs[0]
+	assert.Equal(s.T(), m["grpc.service"], "mwitkow.testproto.TestService", "all lines must contain service name")
+	assert.Equal(s.T(), m["grpc.method"], "PingError", "all lines must contain method name")
+	assert.Equal(s.T(), m["grpc.code"], code.String(), "all lines must contain the correct gRPC code")
+	assert.Equal(s.T(), m["level"], level.String(), msg)
+}
+
+func (s *ZRServerOverridenDeciderSuite) TestPingList_HasOverriddenDecider() {
+	stream, err := s.Client.PingList(s.SimpleCtx(), goodPing)
+	require.NoError(s.T(), err, "should not fail on establishing the stream")
+	for {
+		_, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		require.NoError(s.T(), err, "reading stream should not fail")
+	}
+	msgs := s.getOutputJSONs()
+	require.Len(s.T(), msgs, 1, "single log statements should be logged")
+
+	assert.Equal(s.T(), msgs[0]["grpc.service"], "mwitkow.testproto.TestService", "all lines must contain service name")
+	assert.Equal(s.T(), msgs[0]["grpc.method"], "PingList", "all lines must contain method name")
+	assert.Equal(s.T(), msgs[0]["msg"], "some pinglist", "handler's message must contain user message")
+
+	assert.NotContains(s.T(), msgs[0], "grpc.time_ms", "handler's message must not contain default duration")
+	assert.NotContains(s.T(), msgs[0], "grpc.duration", "handler's message must not contain overridden duration")
+}

--- a/logging/zerolog/shared_test.go
+++ b/logging/zerolog/shared_test.go
@@ -1,0 +1,100 @@
+package grpc_zerolog_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zerolog/ctxzr"
+	"io"
+	"testing"
+
+	"context"
+	grpc_ctxtags "github.com/grpc-ecosystem/go-grpc-middleware/tags"
+	grpc_testing "github.com/grpc-ecosystem/go-grpc-middleware/testing"
+	pb_testproto "github.com/grpc-ecosystem/go-grpc-middleware/testing/testproto"
+	"github.com/rs/zerolog"
+)
+
+var (
+	goodPing = &pb_testproto.PingRequest{Value: "something", SleepTimeMs: 9999}
+)
+
+type loggingPingService struct {
+	pb_testproto.TestServiceServer
+}
+
+func (s *loggingPingService) Ping(ctx context.Context, ping *pb_testproto.PingRequest) (*pb_testproto.PingResponse, error) {
+	grpc_ctxtags.Extract(ctx).Set("custom_tags.string", "something").Set("custom_tags.int", 1337)
+	ctxzr.AddFields(ctx, map[string]interface{}{"custom_field": "custom_value"})
+	var ctxLog = ctxzr.Extract(ctx)
+	ctxLog.Fields["msg"] = "some ping"
+	ctxLog.Logger.Info().Fields(ctxLog.Fields).Send()
+
+	return s.TestServiceServer.Ping(ctx, ping)
+}
+
+func (s *loggingPingService) PingError(ctx context.Context, ping *pb_testproto.PingRequest) (*pb_testproto.Empty, error) {
+	return s.TestServiceServer.PingError(ctx, ping)
+}
+
+func (s *loggingPingService) PingList(ping *pb_testproto.PingRequest, stream pb_testproto.TestService_PingListServer) error {
+	grpc_ctxtags.Extract(stream.Context()).Set("custom_tags.string", "something").Set("custom_tags.int", 1337)
+	var ctxLog = ctxzr.Extract(stream.Context())
+	ctxLog.Fields["msg"] = "some pinglist"
+	ctxLog.Logger.Info().Fields(ctxLog.Fields).Send()
+	return s.TestServiceServer.PingList(ping, stream)
+
+}
+
+func (s *loggingPingService) PingEmpty(ctx context.Context, empty *pb_testproto.Empty) (*pb_testproto.PingResponse, error) {
+	return s.TestServiceServer.PingEmpty(ctx, empty)
+}
+
+type ZRBaseSuite struct {
+	*grpc_testing.InterceptorTestSuite
+	mutexBuffer *grpc_testing.MutexReadWriter
+	buffer      *bytes.Buffer
+	logger      *ctxzr.CtxLogger
+}
+
+func newZRBaseSuite(t *testing.T) *ZRBaseSuite {
+	b := &bytes.Buffer{}
+	muB := grpc_testing.NewMutexReadWriter(b)
+	zerolog.SetGlobalLevel(zerolog.InfoLevel)
+
+	logger := zerolog.New(muB)
+	fields := make(map[string]interface{}, 0)
+	return &ZRBaseSuite{
+		logger:      &ctxzr.CtxLogger{Logger: &logger, Fields: fields},
+		buffer:      b,
+		mutexBuffer: muB,
+		InterceptorTestSuite: &grpc_testing.InterceptorTestSuite{
+			TestService: &loggingPingService{&grpc_testing.TestPingService{T: t}},
+		},
+	}
+}
+
+func (s *ZRBaseSuite) SetupTest() {
+	s.mutexBuffer.Lock()
+	s.buffer.Reset()
+	s.mutexBuffer.Unlock()
+}
+
+func (s *ZRBaseSuite) getOutputJSONs() []map[string]interface{} {
+	ret := make([]map[string]interface{}, 0)
+	dec := json.NewDecoder(s.mutexBuffer)
+
+	for {
+		var val map[string]interface{}
+		err := dec.Decode(&val)
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			s.T().Fatalf("failed decoding output from Zerolog JSON: %v", err)
+		}
+
+		ret = append(ret, val)
+	}
+
+	return ret
+}

--- a/ratelimit/ratelimit.go
+++ b/ratelimit/ratelimit.go
@@ -1,7 +1,7 @@
 package ratelimit
 
 import (
-	"golang.org/x/net/context"
+	"context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"

--- a/testing/testproto/test.pb.go
+++ b/testing/testproto/test.pb.go
@@ -8,8 +8,6 @@ import (
 	fmt "fmt"
 	proto "github.com/golang/protobuf/proto"
 	grpc "google.golang.org/grpc"
-	codes "google.golang.org/grpc/codes"
-	status "google.golang.org/grpc/status"
 	math "math"
 )
 
@@ -312,26 +310,6 @@ type TestServiceServer interface {
 	PingError(context.Context, *PingRequest) (*Empty, error)
 	PingList(*PingRequest, TestService_PingListServer) error
 	PingStream(TestService_PingStreamServer) error
-}
-
-// UnimplementedTestServiceServer can be embedded to have forward compatible implementations.
-type UnimplementedTestServiceServer struct {
-}
-
-func (*UnimplementedTestServiceServer) PingEmpty(ctx context.Context, req *Empty) (*PingResponse, error) {
-	return nil, status.Errorf(codes.Unimplemented, "method PingEmpty not implemented")
-}
-func (*UnimplementedTestServiceServer) Ping(ctx context.Context, req *PingRequest) (*PingResponse, error) {
-	return nil, status.Errorf(codes.Unimplemented, "method Ping not implemented")
-}
-func (*UnimplementedTestServiceServer) PingError(ctx context.Context, req *PingRequest) (*Empty, error) {
-	return nil, status.Errorf(codes.Unimplemented, "method PingError not implemented")
-}
-func (*UnimplementedTestServiceServer) PingList(req *PingRequest, srv TestService_PingListServer) error {
-	return status.Errorf(codes.Unimplemented, "method PingList not implemented")
-}
-func (*UnimplementedTestServiceServer) PingStream(srv TestService_PingStreamServer) error {
-	return status.Errorf(codes.Unimplemented, "method PingStream not implemented")
 }
 
 func RegisterTestServiceServer(s *grpc.Server, srv TestServiceServer) {


### PR DESCRIPTION
Inspired from [adrien-f](https://github.com/adrien-f) [PR](https://github.com/grpc-ecosystem/go-grpc-middleware/pull/223), I want to add [Zerolog](https://github.com/rs/zerolog) logging into that project.

For benchmarks, you can visit [logbench](http://hackemist.com/logbench/) site. As seen, Zerolog is much faster than Logrus and Zap.
