### PR TITLE
Make SetInContext and NewTags to be public.

### DIFF
--- a/tags/context.go
+++ b/tags/context.go
@@ -69,10 +69,10 @@ func Extract(ctx context.Context) Tags {
 	return t
 }
 
-func setInContext(ctx context.Context, tags Tags) context.Context {
+func SetInContext(ctx context.Context, tags Tags) context.Context {
 	return context.WithValue(ctx, ctxMarkerKey, tags)
 }
 
-func newTags() Tags {
+func NewTags() Tags {
 	return &mapTags{values: make(map[string]interface{})}
 }

--- a/tags/interceptors.go
+++ b/tags/interceptors.go
@@ -6,9 +6,10 @@ package grpc_ctxtags
 import (
 	"context"
 
-	"github.com/grpc-ecosystem/go-grpc-middleware"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/peer"
+
+	"github.com/grpc-ecosystem/go-grpc-middleware"
 )
 
 // UnaryServerInterceptor returns a new unary server interceptors that sets the values for request tags.
@@ -67,11 +68,11 @@ func (w *wrappedStream) RecvMsg(m interface{}) error {
 }
 
 func newTagsForCtx(ctx context.Context) context.Context {
-	t := newTags()
+	t := NewTags()
 	if peer, ok := peer.FromContext(ctx); ok {
 		t.Set("peer.address", peer.Addr.String())
 	}
-	return setInContext(ctx, t)
+	return SetInContext(ctx, t)
 }
 
 func setRequestFieldTags(ctx context.Context, f RequestFieldExtractorFunc, fullMethodName string, req interface{}) {


### PR DESCRIPTION
In case if you create grpc client not in grpc service
you don't have possibility to set tags.
This patch makes some private API
to be public and fix described case.
fixes #182.