### PR TITLE
recovery: add custom func on recovery example

### DIFF
--- a/recovery/examples_test.go
+++ b/recovery/examples_test.go
@@ -6,6 +6,7 @@ package grpc_recovery_test
 import (
 	"github.com/grpc-ecosystem/go-grpc-middleware"
 	"github.com/grpc-ecosystem/go-grpc-middleware/recovery"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc"
 )
 
@@ -15,6 +16,10 @@ var (
 
 // Initialization shows an initialization sequence with a custom recovery handler func.
 func Example_initialization() {
+	// Define customfunc to handle panic
+	customFunc = func(p interface{}) (err error) {
+		return grpc.Errorf(codes.Unknown, "panic triggered: %v", p)
+	}
 	// Shared options for the logger, with a custom gRPC code to log level function.
 	opts := []grpc_recovery.Option{
 		grpc_recovery.WithRecoveryHandler(customFunc),


### PR DESCRIPTION
It seems that handler function of recovery is missing on code example of recovery. It may cause confusion for users. But, there is valid handler function on test suite so add them.