### PR TITLE
feature(tracing): Add datadog support to injectOpenTracingIdsToTags

### DIFF
--- a/tracing/opentracing/id_extract.go
+++ b/tracing/opentracing/id_extract.go
@@ -23,6 +23,8 @@ const (
 // https://github.com/opentracing/basictracer-go/blob/1b32af207119a14b1b231d451df3ed04a72efebf/propagation_ot.go#L26
 // Jaeger from Uber use one-key schema with next format '{trace-id}:{span-id}:{parent-span-id}:{flags}'
 // https://www.jaegertracing.io/docs/client-libraries/#trace-span-identity
+// Datadog uses keys ending with 'trace-id' and 'parent-id' (for span) by default:
+// https://github.com/DataDog/dd-trace-go/blob/v1/ddtrace/tracer/textmap.go#L77
 func injectOpentracingIdsToTags(span opentracing.Span, tags grpc_ctxtags.Tags) {
 	if err := span.Tracer().Inject(span.Context(), opentracing.HTTPHeaders, &tagsCarrier{tags}); err != nil {
 		grpclog.Infof("grpc_opentracing: failed extracting trace info into ctx %v", err)
@@ -63,5 +65,13 @@ func (t *tagsCarrier) Set(key, val string) {
 				t.Tags.Set(TagSampled, "false")
 			}
 		}
+	}
+
+	if strings.HasSuffix(key, "trace-id") {
+		t.Tags.Set(TagTraceId, val)
+	}
+
+	if strings.HasSuffix(key, "parent-id") {
+		t.Tags.Set(TagSpanId, val)
 	}
 }


### PR DESCRIPTION
Datadog uses a convention for it's keys that is currently not supported.

See https://github.com/DataDog/dd-trace-go/blob/v1/ddtrace/tracer/textmap.go#L77 and https://github.com/DataDog/dd-trace-go/blob/v1/ddtrace/tracer/textmap.go#L221 for some background.

This PR adds a few additional heuristics to `injectOpenTracingIdsToTags` which should help capture these.

Alternatively, if you are ok with using reflection: you can cast the span to a ddtrace.SpanContext which does give direct access to the spanid and traceid, allowing you to bypass the inject call altogether.