### PR TITLE
add build target for go 1.13 for travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: go
 go:
   - 1.11.x
   - 1.12.x
+  - 1.13.x
 
 env:
   global:
@@ -10,6 +11,6 @@ env:
 
 script:
  - make test
- 
+
 after_success:
   - bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
This will add a build target or go version 1.13 for travis.