### PR TITLE
Add option to change trace carrier header name

### DIFF
--- a/tracing/opentracing/options.go
+++ b/tracing/opentracing/options.go
@@ -22,8 +22,9 @@ var (
 type FilterFunc func(ctx context.Context, fullMethodName string) bool
 
 type options struct {
-	filterOutFunc FilterFunc
-	tracer        opentracing.Tracer
+	filterOutFunc   FilterFunc
+	tracer          opentracing.Tracer
+	traceHeaderName string
 }
 
 func evaluateOptions(opts []Option) *options {
@@ -35,6 +36,9 @@ func evaluateOptions(opts []Option) *options {
 	if optCopy.tracer == nil {
 		optCopy.tracer = opentracing.GlobalTracer()
 	}
+	if optCopy.traceHeaderName == "" {
+		optCopy.traceHeaderName = "uber-trace-id"
+	}
 	return optCopy
 }
 
@@ -44,6 +48,14 @@ type Option func(*options)
 func WithFilterFunc(f FilterFunc) Option {
 	return func(o *options) {
 		o.filterOutFunc = f
+	}
+}
+
+// WithTraceHeaderName customizes the trace header name where trace metadata passed with requests.
+// Default one is `uber-trace-id`
+func WithTraceHeaderName(name string) Option {
+	return func(o *options) {
+		o.traceHeaderName = name
 	}
 }
 

--- a/tracing/opentracing/server_interceptors.go
+++ b/tracing/opentracing/server_interceptors.go
@@ -27,7 +27,7 @@ func UnaryServerInterceptor(opts ...Option) grpc.UnaryServerInterceptor {
 		if o.filterOutFunc != nil && !o.filterOutFunc(ctx, info.FullMethod) {
 			return handler(ctx, req)
 		}
-		newCtx, serverSpan := newServerSpanFromInbound(ctx, o.tracer, info.FullMethod)
+		newCtx, serverSpan := newServerSpanFromInbound(ctx, o.tracer, o.traceHeaderName, info.FullMethod)
 		resp, err := handler(newCtx, req)
 		finishServerSpan(ctx, serverSpan, err)
 		return resp, err
@@ -41,7 +41,7 @@ func StreamServerInterceptor(opts ...Option) grpc.StreamServerInterceptor {
 		if o.filterOutFunc != nil && !o.filterOutFunc(stream.Context(), info.FullMethod) {
 			return handler(srv, stream)
 		}
-		newCtx, serverSpan := newServerSpanFromInbound(stream.Context(), o.tracer, info.FullMethod)
+		newCtx, serverSpan := newServerSpanFromInbound(stream.Context(), o.tracer, o.traceHeaderName, info.FullMethod)
 		wrappedStream := grpc_middleware.WrapServerStream(stream)
 		wrappedStream.WrappedContext = newCtx
 		err := handler(srv, wrappedStream)
@@ -50,7 +50,7 @@ func StreamServerInterceptor(opts ...Option) grpc.StreamServerInterceptor {
 	}
 }
 
-func newServerSpanFromInbound(ctx context.Context, tracer opentracing.Tracer, fullMethodName string) (context.Context, opentracing.Span) {
+func newServerSpanFromInbound(ctx context.Context, tracer opentracing.Tracer, traceHeaderName, fullMethodName string) (context.Context, opentracing.Span) {
 	md := metautils.ExtractIncoming(ctx)
 	parentSpanContext, err := tracer.Extract(opentracing.HTTPHeaders, metadataTextMap(md))
 	if err != nil && err != opentracing.ErrSpanContextNotFound {
@@ -64,7 +64,7 @@ func newServerSpanFromInbound(ctx context.Context, tracer opentracing.Tracer, fu
 		grpcTag,
 	)
 
-	injectOpentracingIdsToTags(serverSpan, grpc_ctxtags.Extract(ctx))
+	injectOpentracingIdsToTags(traceHeaderName, serverSpan, grpc_ctxtags.Extract(ctx))
 	return opentracing.ContextWithSpan(ctx, serverSpan), serverSpan
 }
 


### PR DESCRIPTION
We have different header name from `uber-trace-id` as a carrier of opentracing data. There was no way to change it.

This PR adds option which provides the ability to change trace header name to custom one from default `uber-trace-id`