### PR TITLE
Update doc.go to add missing parens on the example

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -23,7 +23,7 @@ server chaining:
 
 	myServer := grpc.NewServer(
 	    grpc.StreamInterceptor(grpc_middleware.ChainStreamServer(loggingStream, monitoringStream, authStream)),
-	    grpc.UnaryInterceptor(grpc_middleware.ChainUnaryServer(loggingUnary, monitoringUnary, authUnary),
+	    grpc.UnaryInterceptor(grpc_middleware.ChainUnaryServer(loggingUnary, monitoringUnary, authUnary)),
 	)
 
 These interceptors will be executed from left to right: logging, monitoring and auth.


### PR DESCRIPTION
When reading the docs I noticed that there was a missing paren on the example. This does the heavy lifting to add that paren back in 💃