### PR TITLE
Do not stop retrying based on earlier good message from the stream

### DIFF
--- a/retry/retry.go
+++ b/retry/retry.go
@@ -136,7 +136,6 @@ func StreamClientInterceptor(optFuncs ...CallOption) grpc.StreamClientIntercepto
 type serverStreamingRetryingStream struct {
 	grpc.ClientStream
 	bufferedSends []interface{} // single message that the client can sen
-	receivedGood  bool          // indicates whether any prior receives were successful
 	wasClosedSend bool          // indicates that CloseSend was closed
 	parentCtx     context.Context
 	callOpts      *options
@@ -209,17 +208,8 @@ func (s *serverStreamingRetryingStream) RecvMsg(m interface{}) error {
 }
 
 func (s *serverStreamingRetryingStream) receiveMsgAndIndicateRetry(m interface{}) (bool, error) {
-	s.mu.RLock()
-	wasGood := s.receivedGood
-	s.mu.RUnlock()
 	err := s.getStream().RecvMsg(m)
 	if err == nil || err == io.EOF {
-		s.mu.Lock()
-		s.receivedGood = true
-		s.mu.Unlock()
-		return false, err
-	} else if wasGood {
-		// previous RecvMsg in the stream succeeded, no retry logic should interfere
 		return false, err
 	}
 	if isContextError(err) {


### PR DESCRIPTION
- Usually, the pattern is to establish a stream and read messages in the loop until io.EOF. If the server becomes unavailable after sending a good message in the stream, we stop retrying in the middleware based on an earlier good message.  This forces the caller to check for codes.Unavailable and initiate establishing the stream and read again. The patch handles this case inside the middleware.