### PR TITLE
Update streaming interceptor example

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -63,7 +63,7 @@ needed. For example:
 	func FakeAuthStreamingInterceptor(srv interface{}, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
 	   newStream := grpc_middleware.WrapServerStream(stream)
 	   newStream.WrappedContext = context.WithValue(ctx, "user_id", "john@example.com")
-	   return handler(srv, stream)
+	   return handler(srv, newStream)
 	}
 */
 package grpc_middleware


### PR DESCRIPTION
Return new stream with wrapped context instead of original so changes will be passed further the chain