### PR TITLE
Client unary interceptor timeout

### DIFF
--- a/timeout/doc.go
+++ b/timeout/doc.go
@@ -1,0 +1,11 @@
+// Copyright 2017 David Ackroyd. All Rights Reserved.
+// See LICENSE for licensing terms.
+
+/*
+`grpc_timeout` are interceptors that timeout for gRPC client calls.
+
+Client Side Timeout Middleware
+
+Please see examples for simple examples of use.
+*/
+package grpc_timeout

--- a/timeout/examples_test.go
+++ b/timeout/examples_test.go
@@ -1,0 +1,42 @@
+// Copyright 2017 David Ackroyd. All Rights Reserved.
+// See LICENSE for licensing terms.
+
+package grpc_timeout_test
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	mwitkow_testproto "github.com/grpc-ecosystem/go-grpc-middleware/testing/testproto"
+	grpc_timeout "github.com/grpc-ecosystem/go-grpc-middleware/timeout"
+	"google.golang.org/grpc"
+)
+
+// Initialization shows an initialization sequence with a custom client request timeout.
+func Example_initialization() {
+	clientConn, err := grpc.Dial(
+		"ServerAddr",
+		grpc.WithUnaryInterceptor(
+			// Set your client request timeout
+			grpc_timeout.TimeoutUnaryClientInterceptor(20*time.Millisecond),
+		),
+	)
+
+	// Handle connection error
+	if err != nil {
+		panic(err)
+	}
+
+	// Initialize your grpc service with connection
+	testServiceClient := mwitkow_testproto.NewTestServiceClient(clientConn)
+	resp, err := testServiceClient.PingEmpty(context.TODO(), &mwitkow_testproto.Empty{})
+
+	// Handle request error
+	if err != nil {
+		panic(err)
+	}
+
+	// Use grpc response value
+	fmt.Println(resp.Value)
+}

--- a/timeout/timeout.go
+++ b/timeout/timeout.go
@@ -1,0 +1,17 @@
+package grpc_timeout
+
+import (
+	"context"
+	"time"
+
+	"google.golang.org/grpc"
+)
+
+// TimeoutUnaryClientInterceptor returns a new unary client interceptor that sets a timeout on the request context.
+func TimeoutUnaryClientInterceptor(timeout time.Duration) grpc.UnaryClientInterceptor {
+	return func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+		timedCtx, cancel := context.WithTimeout(ctx, timeout)
+		defer cancel()
+		return invoker(timedCtx, method, req, reply, cc, opts...)
+	}
+}

--- a/timeout/timeout_test.go
+++ b/timeout/timeout_test.go
@@ -1,0 +1,47 @@
+package grpc_timeout_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	grpc_testing "github.com/grpc-ecosystem/go-grpc-middleware/testing"
+	mwitkow_testproto "github.com/grpc-ecosystem/go-grpc-middleware/testing/testproto"
+	"github.com/grpc-ecosystem/go-grpc-middleware/timeout"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc"
+)
+
+type TimeoutTestServiceServer struct {
+	sleepTime time.Duration
+	mwitkow_testproto.UnimplementedTestServiceServer
+}
+
+func (t *TimeoutTestServiceServer) PingEmpty(ctx context.Context, req *mwitkow_testproto.Empty) (*mwitkow_testproto.PingResponse, error) {
+	time.Sleep(t.sleepTime)
+	return &mwitkow_testproto.PingResponse{Value: "my_fake_value"}, nil
+}
+
+func TestTimeoutUnaryClientInterceptor(t *testing.T) {
+	server := &TimeoutTestServiceServer{sleepTime: 1 * time.Millisecond}
+
+	its := &grpc_testing.InterceptorTestSuite{
+		ClientOpts: []grpc.DialOption{
+			grpc.WithUnaryInterceptor(grpc_timeout.TimeoutUnaryClientInterceptor(20 * time.Millisecond)),
+		},
+		TestService: server,
+	}
+	its.Suite.SetT(t)
+	its.SetupSuite()
+	defer its.TearDownSuite()
+
+	resp, err := its.Client.PingEmpty(its.SimpleCtx(), &mwitkow_testproto.Empty{})
+	assert.NoError(t, err)
+	assert.NotNil(t, resp)
+	assert.Equal(t, "my_fake_value", resp.Value)
+
+	server.sleepTime = 30 * time.Millisecond
+	resp2, err2 := its.Client.PingEmpty(its.SimpleCtx(), &mwitkow_testproto.Empty{})
+	assert.Nil(t, resp2)
+	assert.EqualError(t, err2, "rpc error: code = DeadlineExceeded desc = context deadline exceeded")
+}


### PR DESCRIPTION
👋  Hi, 

what do you think about this addition?

Do you think it must purpose a most open way to determine the timeout (base on request or other input) in order to have a better control.

Let me know if this functionality already exist, and where?

Thank's for reading