### PR TITLE
v2: Client unary interceptor timeout on v2 branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ myServer := grpc.NewServer(
 
 #### Client
    * [`retry`](interceptors/retry) - a generic gRPC response code retry mechanism, client-side middleware
+   * [`timeout`](interceptors/timeout) - a generic gRPC request timeout, client-side middleware
 
 #### Server
    * [`validator`](interceptors/validator) - codegen inbound message validation from `.proto` options

--- a/interceptors/timeout/doc.go
+++ b/interceptors/timeout/doc.go
@@ -1,0 +1,8 @@
+/*
+`grpc_timeout` are interceptors that timeout for gRPC client calls.
+
+Client Side Timeout Middleware
+
+Please see examples for simple examples of use.
+*/
+package timeout

--- a/interceptors/timeout/examples_test.go
+++ b/interceptors/timeout/examples_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Initialization shows an initialization sequence with a custom client request timeout.
-func Example_initialization() error {
+func Example_initialization() {
 	clientConn, err := grpc.Dial(
 		"ServerAddr",
 		grpc.WithUnaryInterceptor(
@@ -20,14 +20,14 @@ func Example_initialization() error {
 		),
 	)
 	if err != nil {
-		return err
+		log.Fatal(err)
 	}
 
 	// Initialize your grpc service with connection
 	testServiceClient := testpb.NewTestServiceClient(clientConn)
 	resp, err := testServiceClient.PingEmpty(context.TODO(), &testpb.Empty{})
 	if err != nil {
-		return err
+		log.Fatal(err)
 	}
 
 	// Use grpc response value

--- a/interceptors/timeout/examples_test.go
+++ b/interceptors/timeout/examples_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Initialization shows an initialization sequence with a custom client request timeout.
-func Example_initialization() {
+func Example_initialization() error {
 	clientConn, err := grpc.Dial(
 		"ServerAddr",
 		grpc.WithUnaryInterceptor(
@@ -19,19 +19,15 @@ func Example_initialization() {
 			timeout.TimeoutUnaryClientInterceptor(20*time.Millisecond),
 		),
 	)
-
-	// Handle connection error
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	// Initialize your grpc service with connection
 	testServiceClient := testpb.NewTestServiceClient(clientConn)
 	resp, err := testServiceClient.PingEmpty(context.TODO(), &testpb.Empty{})
-
-	// Handle request error
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	// Use grpc response value

--- a/interceptors/timeout/examples_test.go
+++ b/interceptors/timeout/examples_test.go
@@ -2,7 +2,7 @@ package timeout_test
 
 import (
 	"context"
-	"fmt"
+	"log"
 	"time"
 
 	"github.com/grpc-ecosystem/go-grpc-middleware/v2/grpctesting/testpb"
@@ -35,5 +35,5 @@ func Example_initialization() {
 	}
 
 	// Use grpc response value
-	fmt.Println(resp.Value)
+	log.Println(resp.Value)
 }

--- a/interceptors/timeout/examples_test.go
+++ b/interceptors/timeout/examples_test.go
@@ -1,0 +1,39 @@
+package timeout_test
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/grpc-ecosystem/go-grpc-middleware/v2/grpctesting/testpb"
+	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/timeout"
+	"google.golang.org/grpc"
+)
+
+// Initialization shows an initialization sequence with a custom client request timeout.
+func Example_initialization() {
+	clientConn, err := grpc.Dial(
+		"ServerAddr",
+		grpc.WithUnaryInterceptor(
+			// Set your client request timeout
+			timeout.TimeoutUnaryClientInterceptor(20*time.Millisecond),
+		),
+	)
+
+	// Handle connection error
+	if err != nil {
+		panic(err)
+	}
+
+	// Initialize your grpc service with connection
+	testServiceClient := testpb.NewTestServiceClient(clientConn)
+	resp, err := testServiceClient.PingEmpty(context.TODO(), &testpb.Empty{})
+
+	// Handle request error
+	if err != nil {
+		panic(err)
+	}
+
+	// Use grpc response value
+	fmt.Println(resp.Value)
+}

--- a/interceptors/timeout/examples_test.go
+++ b/interceptors/timeout/examples_test.go
@@ -5,8 +5,8 @@ import (
 	"log"
 	"time"
 
-	"github.com/grpc-ecosystem/go-grpc-middleware/v2/grpctesting/testpb"
 	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/timeout"
+	"github.com/grpc-ecosystem/go-grpc-middleware/v2/testing/testpb"
 	"google.golang.org/grpc"
 )
 
@@ -25,7 +25,7 @@ func Example_initialization() {
 
 	// Initialize your grpc service with connection.
 	testServiceClient := testpb.NewTestServiceClient(clientConn)
-	resp, err := testServiceClient.PingEmpty(context.TODO(), &testpb.Empty{})
+	resp, err := testServiceClient.Ping(context.TODO(), &testpb.PingRequest{Value: "my_example_value"})
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/interceptors/timeout/examples_test.go
+++ b/interceptors/timeout/examples_test.go
@@ -15,7 +15,7 @@ func Example_initialization() {
 	clientConn, err := grpc.Dial(
 		"ServerAddr",
 		grpc.WithUnaryInterceptor(
-			// Set your client request timeout
+			// Set your client request timeout.
 			timeout.TimeoutUnaryClientInterceptor(20*time.Millisecond),
 		),
 	)
@@ -23,13 +23,13 @@ func Example_initialization() {
 		log.Fatal(err)
 	}
 
-	// Initialize your grpc service with connection
+	// Initialize your grpc service with connection.
 	testServiceClient := testpb.NewTestServiceClient(clientConn)
 	resp, err := testServiceClient.PingEmpty(context.TODO(), &testpb.Empty{})
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	// Use grpc response value
+	// Use grpc response value.
 	log.Println(resp.Value)
 }

--- a/interceptors/timeout/timeout.go
+++ b/interceptors/timeout/timeout.go
@@ -1,0 +1,17 @@
+package timeout
+
+import (
+	"context"
+	"time"
+
+	"google.golang.org/grpc"
+)
+
+// TimeoutUnaryClientInterceptor returns a new unary client interceptor that sets a timeout on the request context.
+func TimeoutUnaryClientInterceptor(timeout time.Duration) grpc.UnaryClientInterceptor {
+	return func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+		timedCtx, cancel := context.WithTimeout(ctx, timeout)
+		defer cancel()
+		return invoker(timedCtx, method, req, reply, cc, opts...)
+	}
+}

--- a/interceptors/timeout/timeout.go
+++ b/interceptors/timeout/timeout.go
@@ -10,6 +10,9 @@ import (
 // TimeoutUnaryClientInterceptor returns a new unary client interceptor that sets a timeout on the request context.
 func TimeoutUnaryClientInterceptor(timeout time.Duration) grpc.UnaryClientInterceptor {
 	return func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+		if _, ok := ctx.Deadline(); ok {
+			return invoker(ctx, method, req, reply, cc, opts...)
+		}
 		timedCtx, cancel := context.WithTimeout(ctx, timeout)
 		defer cancel()
 		return invoker(timedCtx, method, req, reply, cc, opts...)

--- a/interceptors/timeout/timeout.go
+++ b/interceptors/timeout/timeout.go
@@ -10,9 +10,6 @@ import (
 // TimeoutUnaryClientInterceptor returns a new unary client interceptor that sets a timeout on the request context.
 func TimeoutUnaryClientInterceptor(timeout time.Duration) grpc.UnaryClientInterceptor {
 	return func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
-		if _, ok := ctx.Deadline(); ok {
-			return invoker(ctx, method, req, reply, cc, opts...)
-		}
 		timedCtx, cancel := context.WithTimeout(ctx, timeout)
 		defer cancel()
 		return invoker(timedCtx, method, req, reply, cc, opts...)

--- a/interceptors/timeout/timeout_test.go
+++ b/interceptors/timeout/timeout_test.go
@@ -19,7 +19,7 @@ type TimeoutTestServiceServer struct {
 
 func (t *TimeoutTestServiceServer) PingEmpty(ctx context.Context, req *testpb.Empty) (*testpb.PingResponse, error) {
 	time.Sleep(t.sleepTime)
-	return &testpb.PingResponse{Value: "my_fake_value"}, nil
+	return t.TestPingService.PingEmpty(ctx, req)
 }
 
 func TestTimeoutUnaryClientInterceptor(t *testing.T) {
@@ -27,7 +27,7 @@ func TestTimeoutUnaryClientInterceptor(t *testing.T) {
 
 	its := &grpctesting.InterceptorTestSuite{
 		ClientOpts: []grpc.DialOption{
-			grpc.WithUnaryInterceptor(timeout.TimeoutUnaryClientInterceptor(20 * time.Millisecond)),
+			grpc.WithUnaryInterceptor(timeout.TimeoutUnaryClientInterceptor(10 * time.Millisecond)),
 		},
 		TestService: server,
 	}
@@ -38,7 +38,7 @@ func TestTimeoutUnaryClientInterceptor(t *testing.T) {
 	resp, err := its.Client.PingEmpty(its.SimpleCtx(), &testpb.Empty{})
 	assert.NoError(t, err)
 	assert.NotNil(t, resp)
-	assert.Equal(t, "my_fake_value", resp.Value)
+	assert.Equal(t, "default_response_value", resp.Value)
 
 	server.sleepTime = 30 * time.Millisecond
 	resp2, err2 := its.Client.PingEmpty(its.SimpleCtx(), &testpb.Empty{})

--- a/interceptors/timeout/timeout_test.go
+++ b/interceptors/timeout/timeout_test.go
@@ -1,0 +1,47 @@
+package timeout_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/grpc-ecosystem/go-grpc-middleware/v2/grpctesting"
+	"github.com/grpc-ecosystem/go-grpc-middleware/v2/grpctesting/testpb"
+	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/timeout"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc"
+)
+
+type TimeoutTestServiceServer struct {
+	sleepTime time.Duration
+	grpctesting.TestPingService
+}
+
+func (t *TimeoutTestServiceServer) PingEmpty(ctx context.Context, req *testpb.Empty) (*testpb.PingResponse, error) {
+	time.Sleep(t.sleepTime)
+	return &testpb.PingResponse{Value: "my_fake_value"}, nil
+}
+
+func TestTimeoutUnaryClientInterceptor(t *testing.T) {
+	server := &TimeoutTestServiceServer{sleepTime: 1 * time.Millisecond}
+
+	its := &grpctesting.InterceptorTestSuite{
+		ClientOpts: []grpc.DialOption{
+			grpc.WithUnaryInterceptor(timeout.TimeoutUnaryClientInterceptor(20 * time.Millisecond)),
+		},
+		TestService: server,
+	}
+	its.Suite.SetT(t)
+	its.SetupSuite()
+	defer its.TearDownSuite()
+
+	resp, err := its.Client.PingEmpty(its.SimpleCtx(), &testpb.Empty{})
+	assert.NoError(t, err)
+	assert.NotNil(t, resp)
+	assert.Equal(t, "my_fake_value", resp.Value)
+
+	server.sleepTime = 30 * time.Millisecond
+	resp2, err2 := its.Client.PingEmpty(its.SimpleCtx(), &testpb.Empty{})
+	assert.Nil(t, resp2)
+	assert.EqualError(t, err2, "rpc error: code = DeadlineExceeded desc = context deadline exceeded")
+}

--- a/interceptors/timeout/timeout_test.go
+++ b/interceptors/timeout/timeout_test.go
@@ -18,16 +18,18 @@ type TimeoutTestServiceServer struct {
 }
 
 func (t *TimeoutTestServiceServer) PingEmpty(ctx context.Context, req *testpb.Empty) (*testpb.PingResponse, error) {
-	time.Sleep(t.sleepTime)
+	if t.sleepTime > 0 {
+		time.Sleep(t.sleepTime)
+	}
 	return t.TestPingService.PingEmpty(ctx, req)
 }
 
 func TestTimeoutUnaryClientInterceptor(t *testing.T) {
-	server := &TimeoutTestServiceServer{sleepTime: 1 * time.Millisecond}
+	server := &TimeoutTestServiceServer{}
 
 	its := &grpctesting.InterceptorTestSuite{
 		ClientOpts: []grpc.DialOption{
-			grpc.WithUnaryInterceptor(timeout.TimeoutUnaryClientInterceptor(10 * time.Millisecond)),
+			grpc.WithUnaryInterceptor(timeout.TimeoutUnaryClientInterceptor(100 * time.Millisecond)),
 		},
 		TestService: server,
 	}
@@ -35,22 +37,22 @@ func TestTimeoutUnaryClientInterceptor(t *testing.T) {
 	its.SetupSuite()
 	defer its.TearDownSuite()
 
-	// This call will take 1/10ms for respond, so the client timeout NOT exceed.
+	// This call will take 0/100ms for respond, so the client timeout NOT exceed.
 	resp, err := its.Client.PingEmpty(context.TODO(), &testpb.Empty{})
 	assert.NoError(t, err)
 	assert.NotNil(t, resp)
 	assert.Equal(t, "default_response_value", resp.Value)
 
-	// server will sleep 30ms before respond
-	server.sleepTime = 30 * time.Millisecond
+	// server will sleep 300ms before respond
+	server.sleepTime = 300 * time.Millisecond
 
-	// This call will take 30/10ms for respond, so the client timeout exceed.
+	// This call will take 300/100ms for respond, so the client timeout exceed.
 	resp2, err2 := its.Client.PingEmpty(context.TODO(), &testpb.Empty{})
 	assert.Nil(t, resp2)
 	assert.EqualError(t, err2, "rpc error: code = DeadlineExceeded desc = context deadline exceeded")
 
-	// This call will take 30/40ms for respond, so the client timeout NOT exceed.
-	longerValidityContext, cancel := context.WithTimeout(context.TODO(), 40*time.Millisecond)
+	// This call will take 300/400ms for respond, so the client timeout NOT exceed.
+	longerValidityContext, cancel := context.WithTimeout(context.TODO(), 400*time.Millisecond)
 	defer cancel()
 	resp3, err3 := its.Client.PingEmpty(longerValidityContext, &testpb.Empty{})
 	assert.NoError(t, err3)

--- a/interceptors/timeout/timeout_test.go
+++ b/interceptors/timeout/timeout_test.go
@@ -5,29 +5,28 @@ import (
 	"testing"
 	"time"
 
-	"github.com/grpc-ecosystem/go-grpc-middleware/v2/grpctesting"
-	"github.com/grpc-ecosystem/go-grpc-middleware/v2/grpctesting/testpb"
 	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/timeout"
+	"github.com/grpc-ecosystem/go-grpc-middleware/v2/testing/testpb"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc"
 )
 
 type TimeoutTestServiceServer struct {
 	sleepTime time.Duration
-	grpctesting.TestPingService
+	testpb.TestPingService
 }
 
-func (t *TimeoutTestServiceServer) PingEmpty(ctx context.Context, req *testpb.Empty) (*testpb.PingResponse, error) {
+func (t *TimeoutTestServiceServer) Ping(ctx context.Context, req *testpb.PingRequest) (*testpb.PingResponse, error) {
 	if t.sleepTime > 0 {
 		time.Sleep(t.sleepTime)
 	}
-	return t.TestPingService.PingEmpty(ctx, req)
+	return t.TestPingService.Ping(ctx, req)
 }
 
 func TestTimeoutUnaryClientInterceptor(t *testing.T) {
 	server := &TimeoutTestServiceServer{}
 
-	its := &grpctesting.InterceptorTestSuite{
+	its := &testpb.InterceptorTestSuite{
 		ClientOpts: []grpc.DialOption{
 			grpc.WithUnaryInterceptor(timeout.TimeoutUnaryClientInterceptor(100 * time.Millisecond)),
 		},
@@ -38,7 +37,7 @@ func TestTimeoutUnaryClientInterceptor(t *testing.T) {
 	defer its.TearDownSuite()
 
 	// This call will take 0/100ms for respond, so the client timeout NOT exceed.
-	resp, err := its.Client.PingEmpty(context.TODO(), &testpb.Empty{})
+	resp, err := its.Client.Ping(context.TODO(), &testpb.PingRequest{Value: "default_response_value"})
 	assert.NoError(t, err)
 	assert.NotNil(t, resp)
 	assert.Equal(t, "default_response_value", resp.Value)
@@ -47,15 +46,7 @@ func TestTimeoutUnaryClientInterceptor(t *testing.T) {
 	server.sleepTime = 300 * time.Millisecond
 
 	// This call will take 300/100ms for respond, so the client timeout exceed.
-	resp2, err2 := its.Client.PingEmpty(context.TODO(), &testpb.Empty{})
+	resp2, err2 := its.Client.Ping(context.TODO(), &testpb.PingRequest{})
 	assert.Nil(t, resp2)
 	assert.EqualError(t, err2, "rpc error: code = DeadlineExceeded desc = context deadline exceeded")
-
-	// This call will take 300/400ms for respond, so the client timeout NOT exceed.
-	longerValidityContext, cancel := context.WithTimeout(context.TODO(), 400*time.Millisecond)
-	defer cancel()
-	resp3, err3 := its.Client.PingEmpty(longerValidityContext, &testpb.Empty{})
-	assert.NoError(t, err3)
-	assert.NotNil(t, resp3)
-	assert.Equal(t, "default_response_value", resp.Value)
 }

--- a/interceptors/timeout/timeout_test.go
+++ b/interceptors/timeout/timeout_test.go
@@ -35,7 +35,7 @@ func TestTimeoutUnaryClientInterceptor(t *testing.T) {
 	its.SetupSuite()
 	defer its.TearDownSuite()
 
-	// This call will take 1/10ms for respond, so the client timeout NOT exceed
+	// This call will take 1/10ms for respond, so the client timeout NOT exceed.
 	resp, err := its.Client.PingEmpty(context.TODO(), &testpb.Empty{})
 	assert.NoError(t, err)
 	assert.NotNil(t, resp)
@@ -44,17 +44,16 @@ func TestTimeoutUnaryClientInterceptor(t *testing.T) {
 	// server will sleep 30ms before respond
 	server.sleepTime = 30 * time.Millisecond
 
-	// This call will take 30/10ms for respond, so the client timeout exceed
+	// This call will take 30/10ms for respond, so the client timeout exceed.
 	resp2, err2 := its.Client.PingEmpty(context.TODO(), &testpb.Empty{})
 	assert.Nil(t, resp2)
 	assert.EqualError(t, err2, "rpc error: code = DeadlineExceeded desc = context deadline exceeded")
 
-	// This call will take 30/40ms for respond, so the client timeout NOT exceed
+	// This call will take 30/40ms for respond, so the client timeout NOT exceed.
 	longerValidityContext, cancel := context.WithTimeout(context.TODO(), 40*time.Millisecond)
 	defer cancel()
 	resp3, err3 := its.Client.PingEmpty(longerValidityContext, &testpb.Empty{})
 	assert.NoError(t, err3)
 	assert.NotNil(t, resp3)
 	assert.Equal(t, "default_response_value", resp.Value)
-
 }


### PR DESCRIPTION
👋  Hi, 
this PR is related to the first one on the v1 #329 
It was reworked for the v2 branch