### PR TITLE
set CommonName to example.com in the generated cert

### DIFF
--- a/testing/interceptor_suite.go
+++ b/testing/interceptor_suite.go
@@ -173,7 +173,7 @@ func generateCertAndKey(san []string) ([]byte, []byte, error) {
 	template := x509.Certificate{
 		SerialNumber: serialNumber,
 		Subject: pkix.Name{
-			CommonName: "Certify Test Cert",
+			CommonName: "example.com",
 		},
 		NotBefore:             notBefore,
 		NotAfter:              notAfter,


### PR DESCRIPTION
cherry-pick from v2 https://github.com/grpc-ecosystem/go-grpc-middleware/pull/331/commits/538dc63ce7bdb8edbb7eff82d12b890f0fb139ec