### PR TITLE
add all make target, reword instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,10 +6,9 @@ Fork, then clone the repo:
 
 ```bash
 git clone git@github.com:your-username/go-grpc-middleware.git
-```    
-Before submitting a patch, please make sure to run the following make commands for running checks - 
-Before submitting a patch, please make sure to run the following make commands for running
-formatting check, regenerate proto files, and run tests and linters:
+```
+Before submitting a patch, please make sure to run the following make commands to execute the
+formatting check, regenerate the proto files, and run the tests and linters:
 ```powershell
 make fmt : Run formatting across all go files
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,8 @@ Fork, then clone the repo:
 git clone git@github.com:your-username/go-grpc-middleware.git
 ```    
 Before submitting a patch, please make sure to run the following make commands for running checks - 
-Make commands for running formatting/tests/generate proto files/vetting
+Before submitting a patch, please make sure to run the following make commands for running
+formatting check, regenerate proto files, and run tests and linters:
 ```powershell
 make fmt : Run formatting across all go files
 
@@ -16,7 +17,7 @@ make proto : Generate proto files
 
 make test : Run all the tests
 
-make vet : Run vetting across all go files
+make lint : Run linting across all go files
 ```
 
 One command to rule them all:
@@ -25,7 +26,7 @@ One command to rule them all:
 make all
 ```
 
-This will `vet`, `fmt`, regenerate documentation and run all tests.
+This will `lint`, `fmt`, regenerate proto files and documentation and run all tests.
 
 
 Push to your fork and open a pull request.

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,8 @@ define require_clean_work_tree
 
 endef
 
+all: fmt proto lint test
+
 .PHONY: fmt
 fmt: $(GOIMPORTS)
 	@echo "Running fmt for all modules: $(MODULES)"
@@ -65,7 +67,7 @@ test_module:
 #      --cpu-profile-path string   Path to CPU profile output file
 #      --mem-profile-path string   Path to memory profile output file
 # to debug big allocations during linting.
-lint: ## Runs various static analysis against our code.
+lint: ## Runs various static analysis tools against our code.
 lint: fmt $(FAILLINT) $(GOLANGCI_LINT) $(MISSPELL)
 	@echo "Running lint for all modules: $(MODULES)"
 	./scripts/git-tree.sh


### PR DESCRIPTION
PR adds the missing `all` target and rewords some instructions in the contribution guide.