### PR TITLE
remove 1.11 and 1.12 from travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 sudo: false
 language: go
 go:
-  - 1.11.x
-  - 1.12.x
   - 1.13.x
   - 1.14.x
   - 1.15.x


### PR DESCRIPTION
PR removes 1.11 and 1.12 to avoid the build error due to the grpc dependency.