### PR TITLE
remove 1.12.x from build config for consistency with master

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: [ 1.13.x', '1.14.x', '1.15.x' ]
+        go: [ '1.13.x', '1.14.x', '1.15.x' ]
         platform: [ubuntu-latest, macos-latest]
     steps:
       - name: Checkout code into the Go module directory.

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: [ '1.12.x', '1.13.x', '1.14.x', '1.15.x' ]
+        go: [ 1.13.x', '1.14.x', '1.15.x' ]
         platform: [ubuntu-latest, macos-latest]
     steps:
       - name: Checkout code into the Go module directory.


### PR DESCRIPTION
per @johanbrandhorst's request https://github.com/grpc-ecosystem/go-grpc-middleware/pull/336#issuecomment-689489765