### PR TITLE
Fix the special case for jaeger format traceid extraction

### DIFF
--- a/tracing/opentracing/id_extract.go
+++ b/tracing/opentracing/id_extract.go
@@ -40,20 +40,6 @@ type tagsCarrier struct {
 
 func (t *tagsCarrier) Set(key, val string) {
 	key = strings.ToLower(key)
-	if strings.Contains(key, "traceid") {
-		t.Tags.Set(TagTraceId, val) // this will most likely be base-16 (hex) encoded
-	}
-
-	if strings.Contains(key, "spanid") && !strings.Contains(strings.ToLower(key), "parent") {
-		t.Tags.Set(TagSpanId, val) // this will most likely be base-16 (hex) encoded
-	}
-
-	if strings.Contains(key, "sampled") {
-		switch val {
-		case "true", "false":
-			t.Tags.Set(TagSampled, val)
-		}
-	}
 
 	if key == t.traceHeaderName {
 		parts := strings.Split(val, ":")
@@ -66,6 +52,23 @@ func (t *tagsCarrier) Set(key, val string) {
 			} else {
 				t.Tags.Set(TagSampled, "false")
 			}
+
+			return
+		}
+	}
+
+	if strings.Contains(key, "traceid") {
+		t.Tags.Set(TagTraceId, val) // this will most likely be base-16 (hex) encoded
+	}
+
+	if strings.Contains(key, "spanid") && !strings.Contains(strings.ToLower(key), "parent") {
+		t.Tags.Set(TagSpanId, val) // this will most likely be base-16 (hex) encoded
+	}
+
+	if strings.Contains(key, "sampled") {
+		switch val {
+		case "true", "false":
+			t.Tags.Set(TagSampled, val)
 		}
 	}
 

--- a/tracing/opentracing/id_extract_test.go
+++ b/tracing/opentracing/id_extract_test.go
@@ -1,0 +1,32 @@
+package grpc_opentracing
+
+import (
+	"fmt"
+	grpc_ctxtags "github.com/grpc-ecosystem/go-grpc-middleware/tags"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestTagsCarrier_Set_JaegerTraceFormat(t *testing.T) {
+	var (
+		fakeTraceSampled   = 1
+		fakeInboundTraceId = "deadbeef"
+		fakeInboundSpanId  = "c0decafe"
+		traceHeaderName    = "uber-trace-id"
+	)
+
+	traceHeaderValue := fmt.Sprintf("%s:%s:%s:%d", fakeInboundTraceId, fakeInboundSpanId, fakeInboundSpanId, fakeTraceSampled)
+
+	c := &tagsCarrier{
+		Tags:            grpc_ctxtags.NewTags(),
+		traceHeaderName: traceHeaderName,
+	}
+
+	c.Set(traceHeaderName, traceHeaderValue)
+
+	assert.EqualValues(t, map[string]interface{}{
+		TagTraceId: fakeInboundTraceId,
+		TagSpanId:  fakeInboundSpanId,
+		TagSampled: "true",
+	}, c.Tags.Values())
+}


### PR DESCRIPTION
PR #262 introduces a regression where special parsing for the jaeger format traceid extraction is overridden with the unparsed value later in the same file.

Where a header matches the traceHeaderName it is preferred over the other matching types using partial string matches.