### PR TITLE
Adding functionality for custom trace operation name

### DIFF
--- a/tracing/opentracing/interceptors_test.go
+++ b/tracing/opentracing/interceptors_test.go
@@ -22,11 +22,11 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 
-	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
-	grpc_ctxtags "github.com/grpc-ecosystem/go-grpc-middleware/tags"
-	grpc_testing "github.com/grpc-ecosystem/go-grpc-middleware/testing"
+	"github.com/grpc-ecosystem/go-grpc-middleware"
+	"github.com/grpc-ecosystem/go-grpc-middleware/tags"
+	"github.com/grpc-ecosystem/go-grpc-middleware/testing"
 	pb_testproto "github.com/grpc-ecosystem/go-grpc-middleware/testing/testproto"
-	grpc_opentracing "github.com/grpc-ecosystem/go-grpc-middleware/tracing/opentracing"
+	"github.com/grpc-ecosystem/go-grpc-middleware/tracing/opentracing"
 )
 
 var (
@@ -205,11 +205,12 @@ func (s *OpentracingSuite) TestPing_CustomOpName() {
 
 	spans := s.mockTracer.FinishedSpans()
 	spanOpNames := make([]string, len(spans))
-
 	for _, span := range spans {
 		spanOpNames = append(spanOpNames, span.OperationName)
 	}
+
 	require.Contains(s.T(), spanOpNames, customOpName, "finished spans must contain the custom operation name")
+
 }
 
 func (s *OpentracingSuite) TestPing_WithUnaryRequestHandlerFunc() {

--- a/tracing/opentracing/interceptors_test.go
+++ b/tracing/opentracing/interceptors_test.go
@@ -22,11 +22,11 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 
-	"github.com/grpc-ecosystem/go-grpc-middleware"
-	"github.com/grpc-ecosystem/go-grpc-middleware/tags"
-	"github.com/grpc-ecosystem/go-grpc-middleware/testing"
+	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
+	grpc_ctxtags "github.com/grpc-ecosystem/go-grpc-middleware/tags"
+	grpc_testing "github.com/grpc-ecosystem/go-grpc-middleware/testing"
 	pb_testproto "github.com/grpc-ecosystem/go-grpc-middleware/testing/testproto"
-	"github.com/grpc-ecosystem/go-grpc-middleware/tracing/opentracing"
+	grpc_opentracing "github.com/grpc-ecosystem/go-grpc-middleware/tracing/opentracing"
 )
 
 var (
@@ -197,7 +197,6 @@ func (s *OpentracingSuite) TestPing_PropagatesTraces() {
 }
 
 func (s *OpentracingSuite) TestPing_CustomOpName() {
-
 	customOpName := "customOpName"
 
 	ctx := s.createContextFromFakeHttpRequestParent(s.SimpleCtx(), true, customOpName)
@@ -206,7 +205,7 @@ func (s *OpentracingSuite) TestPing_CustomOpName() {
 
 	spans := s.mockTracer.FinishedSpans()
 	spanOpNames := make([]string, len(spans))
-	
+
 	for _, span := range spans {
 		spanOpNames = append(spanOpNames, span.OperationName)
 	}

--- a/tracing/opentracing/options.go
+++ b/tracing/opentracing/options.go
@@ -5,6 +5,7 @@ package grpc_opentracing
 
 import (
 	"context"
+
 	"github.com/opentracing/opentracing-go"
 )
 
@@ -23,11 +24,15 @@ type FilterFunc func(ctx context.Context, fullMethodName string) bool
 // UnaryRequestHandlerFunc is a custom request handler
 type UnaryRequestHandlerFunc func(span opentracing.Span, req interface{})
 
+//OpNameFunc is a func that allows custom operation names instead of the gRPC method.
+type OpNameFunc func(string) string
+
 type options struct {
 	filterOutFunc           FilterFunc
 	tracer                  opentracing.Tracer
 	traceHeaderName         string
 	unaryRequestHandlerFunc UnaryRequestHandlerFunc
+	opNameFunc              OpNameFunc
 }
 
 func evaluateOptions(opts []Option) *options {
@@ -73,5 +78,12 @@ func WithTracer(tracer opentracing.Tracer) Option {
 func WithUnaryRequestHandlerFunc(f UnaryRequestHandlerFunc) Option {
 	return func(o *options) {
 		o.unaryRequestHandlerFunc = f
+	}
+}
+
+//WithOpName customizes the trace Operation name
+func WithOpName(f OpNameFunc) Option {
+	return func(o *options) {
+		o.opNameFunc = f
 	}
 }

--- a/tracing/opentracing/options.go
+++ b/tracing/opentracing/options.go
@@ -24,8 +24,8 @@ type FilterFunc func(ctx context.Context, fullMethodName string) bool
 // UnaryRequestHandlerFunc is a custom request handler
 type UnaryRequestHandlerFunc func(span opentracing.Span, req interface{})
 
-//OpNameFunc is a func that allows custom operation names instead of the gRPC method.
-type OpNameFunc func(string) string
+// OpNameFunc is a func that allows custom operation names instead of the gRPC method.
+type OpNameFunc func(method string) string
 
 type options struct {
 	filterOutFunc           FilterFunc
@@ -81,7 +81,7 @@ func WithUnaryRequestHandlerFunc(f UnaryRequestHandlerFunc) Option {
 	}
 }
 
-//WithOpName customizes the trace Operation name
+// WithOpName customizes the trace Operation name
 func WithOpName(f OpNameFunc) Option {
 	return func(o *options) {
 		o.opNameFunc = f

--- a/tracing/opentracing/server_interceptors.go
+++ b/tracing/opentracing/server_interceptors.go
@@ -27,7 +27,11 @@ func UnaryServerInterceptor(opts ...Option) grpc.UnaryServerInterceptor {
 		if o.filterOutFunc != nil && !o.filterOutFunc(ctx, info.FullMethod) {
 			return handler(ctx, req)
 		}
-		newCtx, serverSpan := newServerSpanFromInbound(ctx, o.tracer, o.traceHeaderName, info.FullMethod)
+		opName := info.FullMethod
+		if o.opNameFunc != nil {
+			opName = o.opNameFunc(info.FullMethod)
+		}
+		newCtx, serverSpan := newServerSpanFromInbound(ctx, o.tracer, o.traceHeaderName, opName)
 		if o.unaryRequestHandlerFunc != nil {
 			o.unaryRequestHandlerFunc(serverSpan, req)
 		}
@@ -44,7 +48,11 @@ func StreamServerInterceptor(opts ...Option) grpc.StreamServerInterceptor {
 		if o.filterOutFunc != nil && !o.filterOutFunc(stream.Context(), info.FullMethod) {
 			return handler(srv, stream)
 		}
-		newCtx, serverSpan := newServerSpanFromInbound(stream.Context(), o.tracer, o.traceHeaderName, info.FullMethod)
+		opName := info.FullMethod
+		if o.opNameFunc != nil {
+			opName = o.opNameFunc(info.FullMethod)
+		}
+		newCtx, serverSpan := newServerSpanFromInbound(stream.Context(), o.tracer, o.traceHeaderName, opName)
 		wrappedStream := grpc_middleware.WrapServerStream(stream)
 		wrappedStream.WrappedContext = newCtx
 		err := handler(srv, wrappedStream)
@@ -53,7 +61,7 @@ func StreamServerInterceptor(opts ...Option) grpc.StreamServerInterceptor {
 	}
 }
 
-func newServerSpanFromInbound(ctx context.Context, tracer opentracing.Tracer, traceHeaderName, fullMethodName string) (context.Context, opentracing.Span) {
+func newServerSpanFromInbound(ctx context.Context, tracer opentracing.Tracer, traceHeaderName, opName string) (context.Context, opentracing.Span) {
 	md := metautils.ExtractIncoming(ctx)
 	parentSpanContext, err := tracer.Extract(opentracing.HTTPHeaders, metadataTextMap(md))
 	if err != nil && err != opentracing.ErrSpanContextNotFound {
@@ -61,7 +69,7 @@ func newServerSpanFromInbound(ctx context.Context, tracer opentracing.Tracer, tr
 	}
 
 	serverSpan := tracer.StartSpan(
-		fullMethodName,
+		opName,
 		// this is magical, it attaches the new span to the parent parentSpanContext, and creates an unparented one if empty.
 		ext.RPCServerOption(parentSpanContext),
 		grpcTag,


### PR DESCRIPTION
The proposed changes will allow custom operation names. This will make traces more obvious and neater (in Jaeger, especially) 

Usage:

Decision func for names (based on method):
```go
func MyCustomOp(method string) string {
	switch method {
	case "/Service/Read":
		return "ReadService"
	default:
		return "UNKNOWN_TRACE_NAME"
	}
}
```

Server usage:
```go
grpc.NewServer(grpc.ChainUnaryInterceptor(grpc_opentracing.UnaryServerInterceptor(grpc_opentracing.WithOpName(MyCustomOp))),
	), nil
```