### PR TITLE
[v2] Add skip interceptor

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,9 @@ myServer := grpc.NewServer(
    * [`recovery`](interceptors/recovery) - turn panics into gRPC errors
    * [`ratelimit`](interceptors/ratelimit) - grpc rate limiting by your own limiter
 
+#### Utility
+   * [`skip`](interceptors/skip) - allow users to skip interceptors in certain condition.
+
 
 ## Status
 

--- a/interceptors/reporter.go
+++ b/interceptors/reporter.go
@@ -30,7 +30,7 @@ var (
 	}
 )
 
-func splitMethodName(fullMethod string) (string, string) {
+func SplitMethodName(fullMethod string) (string, string) {
 	fullMethod = strings.TrimPrefix(fullMethod, "/") // remove leading slash
 	if i := strings.Index(fullMethod, "/"); i >= 0 {
 		return fullMethod[:i], fullMethod[i+1:]
@@ -77,6 +77,6 @@ func newReport(typ GRPCType, fullMethod string) report {
 		startTime: time.Now(),
 		rpcType:   typ,
 	}
-	r.service, r.method = splitMethodName(fullMethod)
+	r.service, r.method = SplitMethodName(fullMethod)
 	return r
 }

--- a/interceptors/server.go
+++ b/interceptors/server.go
@@ -31,14 +31,14 @@ func UnaryServerInterceptor(reportable ServerReportable) grpc.UnaryServerInterce
 func StreamServerInterceptor(reportable ServerReportable) grpc.StreamServerInterceptor {
 	return func(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
 		r := newReport(ServerStream, info.FullMethod)
-		reporter, newCtx := reportable.ServerReporter(ss.Context(), nil, streamRPCType(info), r.service, r.method)
+		reporter, newCtx := reportable.ServerReporter(ss.Context(), nil, StreamRPCType(info), r.service, r.method)
 		err := handler(srv, &monitoredServerStream{ServerStream: ss, newCtx: newCtx, reporter: reporter})
 		reporter.PostCall(err, time.Since(r.startTime))
 		return err
 	}
 }
 
-func streamRPCType(info *grpc.StreamServerInfo) GRPCType {
+func StreamRPCType(info *grpc.StreamServerInfo) GRPCType {
 	if info.IsClientStream && !info.IsServerStream {
 		return ClientStream
 	} else if !info.IsClientStream && info.IsServerStream {

--- a/interceptors/skip/doc.go
+++ b/interceptors/skip/doc.go
@@ -1,0 +1,6 @@
+/*
+`skip` allow users to skip interceptors in certain condition.
+
+Users can use grpc type, service name, method name and metadata to determine whether to skip the interceptor.
+*/
+package skip

--- a/interceptors/skip/examples_test.go
+++ b/interceptors/skip/examples_test.go
@@ -18,10 +18,10 @@ func Example_initialization() {
 	)
 }
 
-func exampleAuthFunc(ctx context.Context) (context.Context, error) {
+func dummyAuth(ctx context.Context) (context.Context, error) {
 	return ctx, nil
 }
 
-func ReflectionFilter(ctx context.Context, gRPCType interceptors.GRPCType, service string, method string) bool {
+func SkilReflectionService(ctx context.Context, gRPCType interceptors.GRPCType, service string, method string) bool {
 	return service == "grpc.reflection.v1alpha.ServerReflection"
 }

--- a/interceptors/skip/examples_test.go
+++ b/interceptors/skip/examples_test.go
@@ -1,0 +1,27 @@
+package skip_test
+
+import (
+	"context"
+
+	"google.golang.org/grpc"
+
+	"github.com/grpc-ecosystem/go-grpc-middleware/v2/auth"
+	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors"
+	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/skip"
+)
+
+// Simple example of skipping auth interceptor in the reflection method.
+func Example_initialization() {
+	_ = grpc.NewServer(
+		grpc.UnaryInterceptor(skip.UnaryServerInterceptor(auth.UnaryServerInterceptor(exampleAuthFunc), ReflectionFilter)),
+		grpc.StreamInterceptor(skip.StreamServerInterceptor(auth.StreamServerInterceptor(exampleAuthFunc), ReflectionFilter)),
+	)
+}
+
+func exampleAuthFunc(ctx context.Context) (context.Context, error) {
+	return ctx, nil
+}
+
+func ReflectionFilter(ctx context.Context, gRPCType interceptors.GRPCType, service string, method string) bool {
+	return service == "grpc.reflection.v1alpha.ServerReflection"
+}

--- a/interceptors/skip/interceptor.go
+++ b/interceptors/skip/interceptor.go
@@ -18,7 +18,7 @@ func UnaryServerInterceptor(in grpc.UnaryServerInterceptor, filter Filter) grpc.
 
 	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
 		service, method := interceptors.SplitMethodName(info.FullMethod)
-		if filter(ctx, interceptors.Unary, service, method) {
+		if !filter(ctx, interceptors.Unary, service, method) {
 			// Skip interceptor.
 			return handler(ctx, req)
 		}
@@ -34,7 +34,7 @@ func StreamServerInterceptor(in grpc.StreamServerInterceptor, filter Filter) grp
 
 	return func(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
 		service, method := interceptors.SplitMethodName(info.FullMethod)
-		if filter(ss.Context(), interceptors.StreamRPCType(info), service, method) {
+		if !filter(ss.Context(), interceptors.StreamRPCType(info), service, method) {
 			// Skip interceptor.
 			return handler(srv, ss)
 		}

--- a/interceptors/skip/interceptor.go
+++ b/interceptors/skip/interceptor.go
@@ -8,7 +8,7 @@ import (
 	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors"
 )
 
-type Filter func(ctx context.Context, gRPCType interceptors.GRPCType, service string, method string) bool
+type Filter func(ctx context.Context, typ interceptors.GRPCType, svc string, method string) bool
 
 // UnaryServerInterceptor returns a new unary server interceptor that determines whether to skip the input interceptor.
 func UnaryServerInterceptor(in grpc.UnaryServerInterceptor, filter Filter) grpc.UnaryServerInterceptor {
@@ -19,7 +19,7 @@ func UnaryServerInterceptor(in grpc.UnaryServerInterceptor, filter Filter) grpc.
 	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
 		service, method := interceptors.SplitMethodName(info.FullMethod)
 		if filter(ctx, interceptors.Unary, service, method) {
-			// Skip interceptor
+			// Skip interceptor.
 			return handler(ctx, req)
 		}
 		return in(ctx, req, info, handler)
@@ -35,7 +35,7 @@ func StreamServerInterceptor(in grpc.StreamServerInterceptor, filter Filter) grp
 	return func(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
 		service, method := interceptors.SplitMethodName(info.FullMethod)
 		if filter(ss.Context(), interceptors.StreamRPCType(info), service, method) {
-			// Skip interceptor
+			// Skip interceptor.
 			return handler(srv, ss)
 		}
 		return in(srv, ss, info, handler)

--- a/interceptors/skip/interceptor.go
+++ b/interceptors/skip/interceptor.go
@@ -1,0 +1,43 @@
+package skip
+
+import (
+	"context"
+
+	"google.golang.org/grpc"
+
+	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors"
+)
+
+type Filter func(ctx context.Context, gRPCType interceptors.GRPCType, service string, method string) bool
+
+// UnaryServerInterceptor returns a new unary server interceptor that determines whether to skip the input interceptor.
+func UnaryServerInterceptor(in grpc.UnaryServerInterceptor, filter Filter) grpc.UnaryServerInterceptor {
+	if filter == nil {
+		return in
+	}
+
+	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+		service, method := interceptors.SplitMethodName(info.FullMethod)
+		if filter(ctx, interceptors.Unary, service, method) {
+			// Skip interceptor
+			return handler(ctx, req)
+		}
+		return in(ctx, req, info, handler)
+	}
+}
+
+// StreamServerInterceptor returns a new streaming server interceptor that determines whether to skip the input interceptor.
+func StreamServerInterceptor(in grpc.StreamServerInterceptor, filter Filter) grpc.StreamServerInterceptor {
+	if filter == nil {
+		return in
+	}
+
+	return func(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		service, method := interceptors.SplitMethodName(info.FullMethod)
+		if filter(ss.Context(), interceptors.StreamRPCType(info), service, method) {
+			// Skip interceptor
+			return handler(srv, ss)
+		}
+		return in(srv, ss, info, handler)
+	}
+}

--- a/interceptors/skip/interceptor_test.go
+++ b/interceptors/skip/interceptor_test.go
@@ -87,10 +87,9 @@ func filter(ctx context.Context, gRPCType interceptors.GRPCType, service string,
 	m.Set(keyMethod, method)
 
 	if v := m.Get("skip"); len(v) > 0 && v[0] == "true" {
-
-		return true
+		return false
 	}
-	return false
+	return true
 }
 
 func TestSkipSuite(t *testing.T) {

--- a/interceptors/skip/interceptor_test.go
+++ b/interceptors/skip/interceptor_test.go
@@ -32,10 +32,7 @@ const (
 )
 
 func skipped(ctx context.Context) bool {
-	if len(tags.Extract(ctx).Values()) > 0 {
-		return false
-	}
-	return true
+	return len(tags.Extract(ctx).Values()) <= 0
 }
 
 type skipPingService struct {

--- a/interceptors/skip/interceptor_test.go
+++ b/interceptors/skip/interceptor_test.go
@@ -1,0 +1,198 @@
+package skip_test
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+
+	"github.com/grpc-ecosystem/go-grpc-middleware/v2/grpctesting"
+	"github.com/grpc-ecosystem/go-grpc-middleware/v2/grpctesting/testpb"
+	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors"
+	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/skip"
+	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/tags"
+)
+
+var (
+	goodPing = &testpb.PingRequest{Value: "something", SleepTimeMs: 9999}
+)
+
+const (
+	keyGRPCType = "skip.grpc_type"
+	keyService  = "skip.service"
+	keyMethod   = "skip.method"
+)
+
+func skipped(ctx context.Context) bool {
+	if len(tags.Extract(ctx).Values()) > 0 {
+		return false
+	}
+	return true
+}
+
+type skipPingService struct {
+	testpb.TestServiceServer
+}
+
+func checkMetadata(ctx context.Context, grpcType interceptors.GRPCType, service string, method string) error {
+	m, _ := metadata.FromIncomingContext(ctx)
+	if typeFromMetadata := m.Get(keyGRPCType)[0]; typeFromMetadata != string(grpcType) {
+		return status.Errorf(codes.Internal, fmt.Sprintf("expected grpc type %s, got: %s", grpcType, typeFromMetadata))
+	}
+	if serviceFromMetadata := m.Get(keyService)[0]; serviceFromMetadata != service {
+		return status.Errorf(codes.Internal, fmt.Sprintf("expected service %s, got: %s", service, serviceFromMetadata))
+	}
+	if methodFromMetadata := m.Get(keyMethod)[0]; methodFromMetadata != method {
+		return status.Errorf(codes.Internal, fmt.Sprintf("expected method %s, got: %s", method, methodFromMetadata))
+	}
+	return nil
+}
+
+func (s *skipPingService) Ping(ctx context.Context, _ *testpb.PingRequest) (*testpb.PingResponse, error) {
+	err := checkMetadata(ctx, interceptors.Unary, "grpc_middleware.testpb.TestService", "Ping")
+	if err != nil {
+		return nil, err
+	}
+
+	if skipped(ctx) {
+		return &testpb.PingResponse{Value: "skipped"}, nil
+	}
+
+	return &testpb.PingResponse{}, nil
+}
+
+func (s *skipPingService) PingList(_ *testpb.PingRequest, stream testpb.TestService_PingListServer) error {
+	err := checkMetadata(stream.Context(), interceptors.ServerStream, "grpc_middleware.testpb.TestService", "PingList")
+	if err != nil {
+		return err
+	}
+
+	var out testpb.PingResponse
+	if skipped(stream.Context()) {
+		out.Value = "skipped"
+	}
+	return stream.Send(&out)
+}
+
+func filter(ctx context.Context, gRPCType interceptors.GRPCType, service string, method string) bool {
+	m, _ := metadata.FromIncomingContext(ctx)
+	// Set parameters into metadata
+	m.Set(keyGRPCType, string(gRPCType))
+	m.Set(keyService, service)
+	m.Set(keyMethod, method)
+
+	if v := m.Get("skip"); len(v) > 0 && v[0] == "true" {
+
+		return true
+	}
+	return false
+}
+
+func TestSkipSuite(t *testing.T) {
+	s := &SkipSuite{
+		InterceptorTestSuite: &grpctesting.InterceptorTestSuite{
+			TestService: &skipPingService{&grpctesting.TestPingService{T: t}},
+			ServerOpts: []grpc.ServerOption{
+				grpc.UnaryInterceptor(skip.UnaryServerInterceptor(tags.UnaryServerInterceptor(), filter)),
+				grpc.StreamInterceptor(skip.StreamServerInterceptor(tags.StreamServerInterceptor(), filter)),
+			},
+		},
+	}
+	suite.Run(t, s)
+}
+
+type SkipSuite struct {
+	*grpctesting.InterceptorTestSuite
+}
+
+func (s *SkipSuite) TestPing() {
+	t := s.T()
+
+	testCases := []struct {
+		name string
+		skip bool
+	}{
+		{
+			name: "skip tags interceptor",
+			skip: true,
+		},
+		{
+			name: "do not skip",
+			skip: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var m metadata.MD
+			if tc.skip {
+				m = metadata.New(map[string]string{
+					"skip": "true",
+				})
+			}
+
+			resp, err := s.Client.Ping(metadata.NewOutgoingContext(s.SimpleCtx(), m), goodPing)
+			require.NoError(t, err)
+
+			var value string
+			if tc.skip {
+				value = "skipped"
+			}
+			assert.Equal(t, value, resp.Value)
+		})
+	}
+}
+
+func (s *SkipSuite) TestPingList() {
+	t := s.T()
+
+	testCases := []struct {
+		name string
+		skip bool
+	}{
+		{
+			name: "skip tags interceptor",
+			skip: true,
+		},
+		{
+			name: "do not skip",
+			skip: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var m metadata.MD
+			if tc.skip {
+				m = metadata.New(map[string]string{
+					"skip": "true",
+				})
+			}
+
+			stream, err := s.Client.PingList(metadata.NewOutgoingContext(s.SimpleCtx(), m), goodPing)
+			require.NoError(t, err)
+
+			for {
+				resp, err := stream.Recv()
+				if err == io.EOF {
+					break
+				}
+				require.NoError(s.T(), err)
+
+				var value string
+				if tc.skip {
+					value = "skipped"
+				}
+				assert.Equal(t, value, resp.Value)
+			}
+		})
+	}
+}

--- a/interceptors/tracing/id_extract_test.go
+++ b/interceptors/tracing/id_extract_test.go
@@ -2,9 +2,11 @@ package tracing
 
 import (
 	"fmt"
-	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/tags"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/tags"
 )
 
 func TestTagsCarrier_Set_JaegerTraceFormat(t *testing.T) {


### PR DESCRIPTION
Resolve #363 

It's hard to transfer a `interceptors.UnaryServerInterceptor` into `interceptors.Reporter`, so I use the old way to implement this feature.