### PR TITLE
Fix zap grpclogger verbosity check

### DIFF
--- a/logging/zap/grpclogger.go
+++ b/logging/zap/grpclogger.go
@@ -114,5 +114,5 @@ func (l *zapGrpcLoggerV2) Fatalf(format string, args ...interface{}) {
 }
 
 func (l *zapGrpcLoggerV2) V(level int) bool {
-	return level <= l.verbosity
+	return l.verbosity <= level
 }

--- a/logging/zap/grpclogger_test.go
+++ b/logging/zap/grpclogger_test.go
@@ -1,0 +1,33 @@
+package grpc_zap
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+	"google.golang.org/grpc/grpclog"
+)
+
+func Test_zapGrpcLogger_V(t *testing.T) {
+	// copied from gRPC
+	const (
+		// infoLog indicates Info severity.
+		infoLog int = iota
+		// warningLog indicates Warning severity.
+		warningLog
+		// errorLog indicates Error severity.
+		errorLog
+		// fatalLog indicates Fatal severity.
+		fatalLog
+	)
+
+	core, _ := observer.New(zapcore.DebugLevel)
+	logger := zap.New(core)
+	ReplaceGrpcLoggerV2WithVerbosity(logger, warningLog)
+	assert.False(t, grpclog.V(infoLog))
+	assert.True(t, grpclog.V(warningLog))
+	assert.True(t, grpclog.V(errorLog))
+	assert.True(t, grpclog.V(fatalLog))
+}


### PR DESCRIPTION
Currently it only logs entries that are *lower* or equal to the
configured level, when you want the opposite. This means that by default
only INFO messages are logged, and anything more urgent is dropped.