### PR TITLE
Support customization of timestamp format

### DIFF
--- a/logging/kit/options.go
+++ b/logging/kit/options.go
@@ -11,17 +11,19 @@ import (
 
 var (
 	defaultOptions = &options{
-		shouldLog:    grpc_logging.DefaultDeciderMethod,
-		codeFunc:     grpc_logging.DefaultErrorToCode,
-		durationFunc: DefaultDurationToField,
+		shouldLog:       grpc_logging.DefaultDeciderMethod,
+		codeFunc:        grpc_logging.DefaultErrorToCode,
+		durationFunc:    DefaultDurationToField,
+		timestampFormat: time.RFC3339,
 	}
 )
 
 type options struct {
-	levelFunc    CodeToLevel
-	shouldLog    grpc_logging.Decider
-	codeFunc     grpc_logging.ErrorToCode
-	durationFunc DurationToField
+	levelFunc       CodeToLevel
+	shouldLog       grpc_logging.Decider
+	codeFunc        grpc_logging.ErrorToCode
+	durationFunc    DurationToField
+	timestampFormat string
 }
 
 type Option func(*options)
@@ -77,6 +79,13 @@ func WithCodes(f grpc_logging.ErrorToCode) Option {
 func WithDurationField(f DurationToField) Option {
 	return func(o *options) {
 		o.durationFunc = f
+	}
+}
+
+// WithTimestampFormat customizes the timestamps emitted in the log fields.
+func WithTimestampFormat(format string) Option {
+	return func(o *options) {
+		o.timestampFormat = format
 	}
 }
 

--- a/logging/kit/shared_test.go
+++ b/logging/kit/shared_test.go
@@ -49,9 +49,10 @@ func (s *loggingPingService) PingEmpty(ctx context.Context, empty *pb_testproto.
 
 type kitBaseSuite struct {
 	*grpc_testing.InterceptorTestSuite
-	mutexBuffer *grpc_testing.MutexReadWriter
-	buffer      *bytes.Buffer
-	logger      log.Logger
+	mutexBuffer     *grpc_testing.MutexReadWriter
+	buffer          *bytes.Buffer
+	logger          log.Logger
+	timestampFormat string
 }
 
 func newKitBaseSuite(t *testing.T) *kitBaseSuite {

--- a/logging/logrus/options.go
+++ b/logging/logrus/options.go
@@ -15,20 +15,22 @@ import (
 
 var (
 	defaultOptions = &options{
-		levelFunc:    nil,
-		shouldLog:    grpc_logging.DefaultDeciderMethod,
-		codeFunc:     grpc_logging.DefaultErrorToCode,
-		durationFunc: DefaultDurationToField,
-		messageFunc:  DefaultMessageProducer,
+		levelFunc:       nil,
+		shouldLog:       grpc_logging.DefaultDeciderMethod,
+		codeFunc:        grpc_logging.DefaultErrorToCode,
+		durationFunc:    DefaultDurationToField,
+		messageFunc:     DefaultMessageProducer,
+		timestampFormat: time.RFC3339,
 	}
 )
 
 type options struct {
-	levelFunc    CodeToLevel
-	shouldLog    grpc_logging.Decider
-	codeFunc     grpc_logging.ErrorToCode
-	durationFunc DurationToField
-	messageFunc  MessageProducer
+	levelFunc       CodeToLevel
+	shouldLog       grpc_logging.Decider
+	codeFunc        grpc_logging.ErrorToCode
+	durationFunc    DurationToField
+	messageFunc     MessageProducer
+	timestampFormat string
 }
 
 func evaluateServerOpt(opts []Option) *options {
@@ -91,6 +93,13 @@ func WithDurationField(f DurationToField) Option {
 func WithMessageProducer(f MessageProducer) Option {
 	return func(o *options) {
 		o.messageFunc = f
+	}
+}
+
+// WithTimestampFormat customizes the timestamps emitted in the log fields.
+func WithTimestampFormat(format string) Option {
+	return func(o *options) {
+		o.timestampFormat = format
 	}
 }
 

--- a/logging/logrus/shared_test.go
+++ b/logging/logrus/shared_test.go
@@ -57,9 +57,10 @@ func (s *loggingPingService) PingEmpty(ctx context.Context, empty *pb_testproto.
 
 type logrusBaseSuite struct {
 	*grpc_testing.InterceptorTestSuite
-	mutexBuffer *grpc_testing.MutexReadWriter
-	buffer      *bytes.Buffer
-	logger      *logrus.Logger
+	mutexBuffer     *grpc_testing.MutexReadWriter
+	buffer          *bytes.Buffer
+	logger          *logrus.Logger
+	timestampFormat string
 }
 
 func newLogrusBaseSuite(t *testing.T) *logrusBaseSuite {

--- a/logging/zap/options.go
+++ b/logging/zap/options.go
@@ -13,20 +13,22 @@ import (
 
 var (
 	defaultOptions = &options{
-		levelFunc:    DefaultCodeToLevel,
-		shouldLog:    grpc_logging.DefaultDeciderMethod,
-		codeFunc:     grpc_logging.DefaultErrorToCode,
-		durationFunc: DefaultDurationToField,
-		messageFunc:  DefaultMessageProducer,
+		levelFunc:       DefaultCodeToLevel,
+		shouldLog:       grpc_logging.DefaultDeciderMethod,
+		codeFunc:        grpc_logging.DefaultErrorToCode,
+		durationFunc:    DefaultDurationToField,
+		messageFunc:     DefaultMessageProducer,
+		timestampFormat: time.RFC3339,
 	}
 )
 
 type options struct {
-	levelFunc    CodeToLevel
-	shouldLog    grpc_logging.Decider
-	codeFunc     grpc_logging.ErrorToCode
-	durationFunc DurationToField
-	messageFunc  MessageProducer
+	levelFunc       CodeToLevel
+	shouldLog       grpc_logging.Decider
+	codeFunc        grpc_logging.ErrorToCode
+	durationFunc    DurationToField
+	messageFunc     MessageProducer
+	timestampFormat string
 }
 
 func evaluateServerOpt(opts []Option) *options {
@@ -89,6 +91,13 @@ func WithDurationField(f DurationToField) Option {
 func WithMessageProducer(f MessageProducer) Option {
 	return func(o *options) {
 		o.messageFunc = f
+	}
+}
+
+// WithTimestampFormat customizes the timestamps emitted in the log fields.
+func WithTimestampFormat(format string) Option {
+	return func(o *options) {
+		o.timestampFormat = format
 	}
 }
 

--- a/logging/zap/server_interceptors_test.go
+++ b/logging/zap/server_interceptors_test.go
@@ -34,19 +34,33 @@ func TestZapLoggingSuite(t *testing.T) {
 		t.Skipf("Skipping due to json.RawMessage incompatibility with go1.7")
 		return
 	}
-	opts := []grpc_zap.Option{
-		grpc_zap.WithLevels(customCodeToLevel),
+
+	for _, tcase := range []struct {
+		timestampFormat string
+	}{
+		{
+			timestampFormat: time.RFC3339,
+		},
+		{
+			timestampFormat: "2006-01-02",
+		},
+	} {
+		opts := []grpc_zap.Option{
+			grpc_zap.WithLevels(customCodeToLevel),
+			grpc_zap.WithTimestampFormat(tcase.timestampFormat),
+		}
+		b := newBaseZapSuite(t)
+		b.timestampFormat = tcase.timestampFormat
+		b.InterceptorTestSuite.ServerOpts = []grpc.ServerOption{
+			grpc_middleware.WithStreamServerChain(
+				grpc_ctxtags.StreamServerInterceptor(grpc_ctxtags.WithFieldExtractor(grpc_ctxtags.CodeGenRequestFieldExtractor)),
+				grpc_zap.StreamServerInterceptor(b.log, opts...)),
+			grpc_middleware.WithUnaryServerChain(
+				grpc_ctxtags.UnaryServerInterceptor(grpc_ctxtags.WithFieldExtractor(grpc_ctxtags.CodeGenRequestFieldExtractor)),
+				grpc_zap.UnaryServerInterceptor(b.log, opts...)),
+		}
+		suite.Run(t, &zapServerSuite{b})
 	}
-	b := newBaseZapSuite(t)
-	b.InterceptorTestSuite.ServerOpts = []grpc.ServerOption{
-		grpc_middleware.WithStreamServerChain(
-			grpc_ctxtags.StreamServerInterceptor(grpc_ctxtags.WithFieldExtractor(grpc_ctxtags.CodeGenRequestFieldExtractor)),
-			grpc_zap.StreamServerInterceptor(b.log, opts...)),
-		grpc_middleware.WithUnaryServerChain(
-			grpc_ctxtags.UnaryServerInterceptor(grpc_ctxtags.WithFieldExtractor(grpc_ctxtags.CodeGenRequestFieldExtractor)),
-			grpc_zap.UnaryServerInterceptor(b.log, opts...)),
-	}
-	suite.Run(t, &zapServerSuite{b})
 }
 
 type zapServerSuite struct {
@@ -70,13 +84,13 @@ func (s *zapServerSuite) TestPing_WithCustomTags() {
 
 		assert.Contains(s.T(), m, "custom_tags.int", "all lines must contain `custom_tags.int`")
 		require.Contains(s.T(), m, "grpc.start_time", "all lines must contain the start time")
-		_, err := time.Parse(time.RFC3339, m["grpc.start_time"].(string))
-		assert.NoError(s.T(), err, "should be able to parse start time as RFC3339")
+		_, err := time.Parse(s.timestampFormat, m["grpc.start_time"].(string))
+		assert.NoError(s.T(), err, "should be able to parse start time")
 
 		require.Contains(s.T(), m, "grpc.request.deadline", "all lines must contain the deadline of the call")
-		_, err = time.Parse(time.RFC3339, m["grpc.request.deadline"].(string))
-		require.NoError(s.T(), err, "should be able to parse deadline as RFC3339")
-		assert.Equal(s.T(), m["grpc.request.deadline"], deadline.Format(time.RFC3339), "should have the same deadline that was set by the caller")
+		_, err = time.Parse(s.timestampFormat, m["grpc.request.deadline"].(string))
+		require.NoError(s.T(), err, "should be able to parse deadline")
+		assert.Equal(s.T(), m["grpc.request.deadline"], deadline.Format(s.timestampFormat), "should have the same deadline that was set by the caller")
 	}
 
 	assert.Equal(s.T(), msgs[0]["msg"], "some ping", "handler's message must contain user message")
@@ -130,8 +144,8 @@ func (s *zapServerSuite) TestPingError_WithCustomLevels() {
 		assert.Equal(s.T(), m["msg"], "finished unary call with code "+tcase.code.String(), "needs the correct end message")
 
 		require.Contains(s.T(), m, "grpc.start_time", "all lines must contain the start time")
-		_, err = time.Parse(time.RFC3339, m["grpc.start_time"].(string))
-		assert.NoError(s.T(), err, "should be able to parse start time as RFC3339")
+		_, err = time.Parse(s.timestampFormat, m["grpc.start_time"].(string))
+		assert.NoError(s.T(), err, "should be able to parse start time")
 	}
 }
 
@@ -157,8 +171,8 @@ func (s *zapServerSuite) TestPingList_WithCustomTags() {
 
 		assert.Contains(s.T(), m, "custom_tags.int", "all lines must contain `custom_tags.int` set by AddFields")
 		require.Contains(s.T(), m, "grpc.start_time", "all lines must contain the start time")
-		_, err := time.Parse(time.RFC3339, m["grpc.start_time"].(string))
-		assert.NoError(s.T(), err, "should be able to parse start time as RFC3339")
+		_, err := time.Parse(s.timestampFormat, m["grpc.start_time"].(string))
+		assert.NoError(s.T(), err, "should be able to parse start time")
 	}
 
 	assert.Equal(s.T(), msgs[0]["msg"], "some pinglist", "handler's message must contain user message")

--- a/logging/zap/shared_test.go
+++ b/logging/zap/shared_test.go
@@ -75,9 +75,10 @@ func newBaseZapSuite(t *testing.T) *zapBaseSuite {
 
 type zapBaseSuite struct {
 	*grpc_testing.InterceptorTestSuite
-	mutexBuffer *grpc_testing.MutexReadWriter
-	buffer      *bytes.Buffer
-	log         *zap.Logger
+	mutexBuffer     *grpc_testing.MutexReadWriter
+	buffer          *bytes.Buffer
+	log             *zap.Logger
+	timestampFormat string
 }
 
 func (s *zapBaseSuite) SetupTest() {


### PR DESCRIPTION
By default, RFC3339 timestamps are used, but our application uses a
custom format. This commit enables us to set the format in a consistent
manner.

Closes #131