### PR TITLE
v2: Refactor metrics interceptor and fix tests

### DIFF
--- a/interceptors/client.go
+++ b/interceptors/client.go
@@ -7,6 +7,7 @@ package interceptors
 
 import (
 	"context"
+	"io"
 	"time"
 
 	"google.golang.org/grpc"
@@ -74,7 +75,10 @@ func (s *monitoredClientStream) RecvMsg(m interface{}) error {
 	if err == nil {
 		return nil
 	}
-
-	s.reporter.PostCall(err, time.Since(s.startTime))
+	var postErr error
+	if err != io.EOF {
+		postErr = err
+	}
+	s.reporter.PostCall(postErr, time.Since(s.startTime))
 	return err
 }

--- a/providers/openmetrics/client_interceptor.go
+++ b/providers/openmetrics/client_interceptor.go
@@ -1,35 +1,21 @@
 package metrics
 
 import (
-	openmetrics "github.com/prometheus/client_golang/prometheus"
 	"google.golang.org/grpc"
 
 	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors"
 )
 
-// RegisterClientMetrics returns a custom ClientMetrics object registered
-// with the user's registry, and registers some common metrics associated
-// with every instance.
-func RegisterClientMetrics(registry openmetrics.Registerer) *ClientMetrics {
-	customClientMetrics := NewClientMetrics(registry)
-	customClientMetrics.MustRegister(customClientMetrics.clientStartedCounter)
-	customClientMetrics.MustRegister(customClientMetrics.clientHandledCounter)
-	customClientMetrics.MustRegister(customClientMetrics.clientStreamMsgReceived)
-	customClientMetrics.MustRegister(customClientMetrics.clientStreamMsgSent)
-
-	return customClientMetrics
-}
-
 // UnaryClientInterceptor is a gRPC client-side interceptor that provides Prometheus monitoring for Unary RPCs.
-func UnaryClientInterceptor(clientRegister openmetrics.Registerer) grpc.UnaryClientInterceptor {
+func UnaryClientInterceptor(clientMetrics *ClientMetrics) grpc.UnaryClientInterceptor {
 	return interceptors.UnaryClientInterceptor(&reportable{
-		registry: clientRegister,
+		clientMetrics: clientMetrics,
 	})
 }
 
 // StreamClientInterceptor is a gRPC client-side interceptor that provides Prometheus monitoring for Streaming RPCs.
-func StreamClientInterceptor(clientRegister openmetrics.Registerer) grpc.StreamClientInterceptor {
+func StreamClientInterceptor(clientMetrics *ClientMetrics) grpc.StreamClientInterceptor {
 	return interceptors.StreamClientInterceptor(&reportable{
-		registry: clientRegister,
+		clientMetrics: clientMetrics,
 	})
 }

--- a/providers/openmetrics/client_options.go
+++ b/providers/openmetrics/client_options.go
@@ -1,0 +1,74 @@
+package metrics
+
+import (
+	openmetrics "github.com/prometheus/client_golang/prometheus"
+)
+
+type clientMetricsConfig struct {
+	counterOpts counterOptions
+	// clientHandledHistogram can be nil
+	clientHandledHistogram *openmetrics.HistogramVec
+	// clientStreamRecvHistogram can be nil
+	clientStreamRecvHistogram *openmetrics.HistogramVec
+	// clientStreamSendHistogram can be nil
+	clientStreamSendHistogram *openmetrics.HistogramVec
+}
+
+type ClientMetricsOption func(*clientMetricsConfig)
+
+func (c *clientMetricsConfig) apply(opts []ClientMetricsOption) {
+	for _, o := range opts {
+		o(c)
+	}
+}
+
+func WithClientCounterOptions(opts ...CounterOption) ClientMetricsOption {
+	return func(o *clientMetricsConfig) {
+		o.counterOpts = opts
+	}
+}
+
+// WithClientHandlingTimeHistogram turns on recording of handling time of RPCs.
+// Histogram metrics can be very expensive for Prometheus to retain and query.
+func WithClientHandlingTimeHistogram(opts ...HistogramOption) ClientMetricsOption {
+	return func(o *clientMetricsConfig) {
+		o.clientHandledHistogram = openmetrics.NewHistogramVec(
+			histogramOptions(opts).apply(openmetrics.HistogramOpts{
+				Name:    "grpc_client_handling_seconds",
+				Help:    "Histogram of response latency (seconds) of the gRPC until it is finished by the application.",
+				Buckets: openmetrics.DefBuckets,
+			}),
+			[]string{"grpc_type", "grpc_service", "grpc_method"},
+		)
+	}
+}
+
+// WithClientStreamRecvHistogram turns on recording of single message receive time of streaming RPCs.
+// Histogram metrics can be very expensive for Prometheus to retain and query.
+func WithClientStreamRecvHistogram(opts ...HistogramOption) ClientMetricsOption {
+	return func(o *clientMetricsConfig) {
+		o.clientStreamRecvHistogram = openmetrics.NewHistogramVec(
+			histogramOptions(opts).apply(openmetrics.HistogramOpts{
+				Name:    "grpc_client_msg_recv_handling_seconds",
+				Help:    "Histogram of response latency (seconds) of the gRPC single message receive.",
+				Buckets: openmetrics.DefBuckets,
+			}),
+			[]string{"grpc_type", "grpc_service", "grpc_method"},
+		)
+	}
+}
+
+// WithClientStreamSendHistogram turns on recording of single message send time of streaming RPCs.
+// Histogram metrics can be very expensive for Prometheus to retain and query.
+func WithClientStreamSendHistogram(opts ...HistogramOption) ClientMetricsOption {
+	return func(o *clientMetricsConfig) {
+		o.clientStreamSendHistogram = openmetrics.NewHistogramVec(
+			histogramOptions(opts).apply(openmetrics.HistogramOpts{
+				Name:    "grpc_client_msg_send_handling_seconds",
+				Help:    "Histogram of response latency (seconds) of the gRPC single message send.",
+				Buckets: openmetrics.DefBuckets,
+			}),
+			[]string{"grpc_type", "grpc_service", "grpc_method"},
+		)
+	}
+}

--- a/providers/openmetrics/client_test.go
+++ b/providers/openmetrics/client_test.go
@@ -7,17 +7,13 @@ import (
 	"testing"
 	"time"
 
-	pb_testproto "github.com/grpc-ecosystem/go-grpc-middleware/providers/openmetrics/v2/testproto/v1"
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-)
 
-var (
-	DefaultClientMetrics *ClientMetrics = NewClientMetrics(prometheus.DefaultRegisterer)
+	pb_testproto "github.com/grpc-ecosystem/go-grpc-middleware/providers/openmetrics/v2/testproto/v1"
 )
 
 func TestClientInterceptorSuite(t *testing.T) {
@@ -33,12 +29,13 @@ type ClientInterceptorTestSuite struct {
 	testClient     pb_testproto.TestServiceClient
 	ctx            context.Context
 	cancel         context.CancelFunc
+	clientMetrics  *ClientMetrics
 }
 
 func (s *ClientInterceptorTestSuite) SetupSuite() {
 	var err error
 
-	DefaultClientMetrics.EnableClientHandlingTimeHistogram()
+	s.clientMetrics = NewClientMetrics(WithClientHandlingTimeHistogram())
 
 	s.serverListener, err = net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(s.T(), err, "must be able to allocate a port for serverListener")
@@ -55,8 +52,8 @@ func (s *ClientInterceptorTestSuite) SetupSuite() {
 		s.serverListener.Addr().String(),
 		grpc.WithInsecure(),
 		grpc.WithBlock(),
-		grpc.WithUnaryInterceptor(UnaryClientInterceptor(prometheus.DefaultRegisterer)),
-		grpc.WithStreamInterceptor(StreamClientInterceptor(prometheus.DefaultRegisterer)),
+		grpc.WithUnaryInterceptor(UnaryClientInterceptor(s.clientMetrics)),
+		grpc.WithStreamInterceptor(StreamClientInterceptor(s.clientMetrics)),
 		grpc.WithTimeout(2*time.Second))
 	require.NoError(s.T(), err, "must not error on client Dial")
 	s.testClient = pb_testproto.NewTestServiceClient(s.clientConn)
@@ -67,22 +64,21 @@ func (s *ClientInterceptorTestSuite) SetupTest() {
 	s.ctx, s.cancel = context.WithTimeout(context.TODO(), 2*time.Second)
 
 	// Make sure every test starts with same fresh, intialized metric state.
-	DefaultClientMetrics.clientStartedCounter.Reset()
-	DefaultClientMetrics.clientHandledCounter.Reset()
-	DefaultClientMetrics.clientHandledHistogram.Reset()
-	DefaultClientMetrics.clientStreamMsgReceived.Reset()
-	DefaultClientMetrics.clientStreamMsgSent.Reset()
+	s.clientMetrics.clientStartedCounter.Reset()
+	s.clientMetrics.clientHandledCounter.Reset()
+	s.clientMetrics.clientHandledHistogram.Reset()
+	s.clientMetrics.clientStreamMsgReceived.Reset()
+	s.clientMetrics.clientStreamMsgSent.Reset()
 }
 
 func (s *ClientInterceptorTestSuite) TearDownSuite() {
+	if s.clientConn != nil {
+		s.clientConn.Close()
+	}
 	if s.serverListener != nil {
 		s.server.Stop()
 		s.T().Logf("stopped grpc.Server at: %v", s.serverListener.Addr().String())
 		s.serverListener.Close()
-
-	}
-	if s.clientConn != nil {
-		s.clientConn.Close()
 	}
 }
 
@@ -93,33 +89,34 @@ func (s *ClientInterceptorTestSuite) TearDownTest() {
 func (s *ClientInterceptorTestSuite) TestUnaryIncrementsMetrics() {
 	_, err := s.testClient.PingEmpty(s.ctx, &pb_testproto.PingEmptyRequest{}) // should return with code=OK
 	require.NoError(s.T(), err)
-	requireValue(s.T(), 1, DefaultClientMetrics.clientStartedCounter.WithLabelValues("unary", "mwitkow.testproto.TestService", "PingEmpty"))
-	requireValue(s.T(), 1, DefaultClientMetrics.clientHandledCounter.WithLabelValues("unary", "mwitkow.testproto.TestService", "PingEmpty", "OK"))
-	requireValueHistCount(s.T(), 1, DefaultClientMetrics.clientHandledHistogram.WithLabelValues("unary", "mwitkow.testproto.TestService", "PingEmpty"))
+	requireValue(s.T(), 1, s.clientMetrics.clientStartedCounter.WithLabelValues("unary", "providers.openmetrics.testproto.v1.TestService", "PingEmpty"))
+	requireValue(s.T(), 1, s.clientMetrics.clientHandledCounter.WithLabelValues("unary", "providers.openmetrics.testproto.v1.TestService", "PingEmpty", "OK"))
+	requireValueHistCount(s.T(), 1, s.clientMetrics.clientHandledHistogram.WithLabelValues("unary", "providers.openmetrics.testproto.v1.TestService", "PingEmpty"))
 
 	_, err = s.testClient.PingError(s.ctx, &pb_testproto.PingErrorRequest{ErrorCodeReturned: uint32(codes.FailedPrecondition)}) // should return with code=FailedPrecondition
 	require.Error(s.T(), err)
-	requireValue(s.T(), 1, DefaultClientMetrics.clientStartedCounter.WithLabelValues("unary", "mwitkow.testproto.TestService", "PingError"))
-	requireValue(s.T(), 1, DefaultClientMetrics.clientHandledCounter.WithLabelValues("unary", "mwitkow.testproto.TestService", "PingError", "FailedPrecondition"))
-	requireValueHistCount(s.T(), 1, DefaultClientMetrics.clientHandledHistogram.WithLabelValues("unary", "mwitkow.testproto.TestService", "PingError"))
+	requireValue(s.T(), 1, s.clientMetrics.clientStartedCounter.WithLabelValues("unary", "providers.openmetrics.testproto.v1.TestService", "PingError"))
+	requireValue(s.T(), 1, s.clientMetrics.clientHandledCounter.WithLabelValues("unary", "providers.openmetrics.testproto.v1.TestService", "PingError", "FailedPrecondition"))
+	requireValueHistCount(s.T(), 1, s.clientMetrics.clientHandledHistogram.WithLabelValues("unary", "providers.openmetrics.testproto.v1.TestService", "PingError"))
 }
 
 func (s *ClientInterceptorTestSuite) TestStartedStreamingIncrementsStarted() {
 	_, err := s.testClient.PingList(s.ctx, &pb_testproto.PingListRequest{})
 	require.NoError(s.T(), err)
-	requireValue(s.T(), 1, DefaultClientMetrics.clientStartedCounter.WithLabelValues("server_stream", "mwitkow.testproto.TestService", "PingList"))
+	requireValue(s.T(), 1, s.clientMetrics.clientStartedCounter.WithLabelValues("server_stream", "providers.openmetrics.testproto.v1.TestService", "PingList"))
 
 	_, err = s.testClient.PingList(s.ctx, &pb_testproto.PingListRequest{ErrorCodeReturned: uint32(codes.FailedPrecondition)}) // should return with code=FailedPrecondition
 	require.NoError(s.T(), err, "PingList must not fail immediately")
-	requireValue(s.T(), 2, DefaultClientMetrics.clientStartedCounter.WithLabelValues("server_stream", "mwitkow.testproto.TestService", "PingList"))
+	requireValue(s.T(), 2, s.clientMetrics.clientStartedCounter.WithLabelValues("server_stream", "providers.openmetrics.testproto.v1.TestService", "PingList"))
 }
 
 func (s *ClientInterceptorTestSuite) TestStreamingIncrementsMetrics() {
-	ss, _ := s.testClient.PingList(s.ctx, &pb_testproto.PingListRequest{}) // should return with code=OK
+	ss, err := s.testClient.PingList(s.ctx, &pb_testproto.PingListRequest{}) // should return with code=OK
+	require.NoError(s.T(), err)
 	// Do a read, just for kicks.
 	count := 0
 	for {
-		_, err := ss.Recv()
+		_, err = ss.Recv()
 		if err == io.EOF {
 			break
 		}
@@ -128,13 +125,13 @@ func (s *ClientInterceptorTestSuite) TestStreamingIncrementsMetrics() {
 	}
 	require.EqualValues(s.T(), countListResponses, count, "Number of received msg on the wire must match")
 
-	requireValue(s.T(), 1, DefaultClientMetrics.clientStartedCounter.WithLabelValues("server_stream", "mwitkow.testproto.TestService", "PingList"))
-	requireValue(s.T(), 1, DefaultClientMetrics.clientHandledCounter.WithLabelValues("server_stream", "mwitkow.testproto.TestService", "PingList", "OK"))
-	requireValue(s.T(), countListResponses, DefaultClientMetrics.clientStreamMsgReceived.WithLabelValues("server_stream", "mwitkow.testproto.TestService", "PingList"))
-	requireValue(s.T(), 1, DefaultClientMetrics.clientStreamMsgSent.WithLabelValues("server_stream", "mwitkow.testproto.TestService", "PingList"))
-	requireValueHistCount(s.T(), 1, DefaultClientMetrics.clientHandledHistogram.WithLabelValues("server_stream", "mwitkow.testproto.TestService", "PingList"))
+	requireValue(s.T(), 1, s.clientMetrics.clientStartedCounter.WithLabelValues("server_stream", "providers.openmetrics.testproto.v1.TestService", "PingList"))
+	requireValue(s.T(), 1, s.clientMetrics.clientHandledCounter.WithLabelValues("server_stream", "providers.openmetrics.testproto.v1.TestService", "PingList", "OK"))
+	requireValue(s.T(), countListResponses+1 /* + EOF */, s.clientMetrics.clientStreamMsgReceived.WithLabelValues("server_stream", "providers.openmetrics.testproto.v1.TestService", "PingList"))
+	requireValue(s.T(), 1, s.clientMetrics.clientStreamMsgSent.WithLabelValues("server_stream", "providers.openmetrics.testproto.v1.TestService", "PingList"))
+	requireValueHistCount(s.T(), 1, s.clientMetrics.clientHandledHistogram.WithLabelValues("server_stream", "providers.openmetrics.testproto.v1.TestService", "PingList"))
 
-	ss, err := s.testClient.PingList(s.ctx, &pb_testproto.PingListRequest{ErrorCodeReturned: uint32(codes.FailedPrecondition)}) // should return with code=FailedPrecondition
+	ss, err = s.testClient.PingList(s.ctx, &pb_testproto.PingListRequest{ErrorCodeReturned: uint32(codes.FailedPrecondition)}) // should return with code=FailedPrecondition
 	require.NoError(s.T(), err, "PingList must not fail immediately")
 
 	// Do a read, just to progate errors.
@@ -142,7 +139,7 @@ func (s *ClientInterceptorTestSuite) TestStreamingIncrementsMetrics() {
 	st, _ := status.FromError(err)
 	require.Equal(s.T(), codes.FailedPrecondition, st.Code(), "Recv must return FailedPrecondition, otherwise the test is wrong")
 
-	requireValue(s.T(), 2, DefaultClientMetrics.clientStartedCounter.WithLabelValues("server_stream", "mwitkow.testproto.TestService", "PingList"))
-	requireValue(s.T(), 1, DefaultClientMetrics.clientHandledCounter.WithLabelValues("server_stream", "mwitkow.testproto.TestService", "PingList", "FailedPrecondition"))
-	requireValueHistCount(s.T(), 2, DefaultClientMetrics.clientHandledHistogram.WithLabelValues("server_stream", "mwitkow.testproto.TestService", "PingList"))
+	requireValue(s.T(), 2, s.clientMetrics.clientStartedCounter.WithLabelValues("server_stream", "providers.openmetrics.testproto.v1.TestService", "PingList"))
+	requireValue(s.T(), 1, s.clientMetrics.clientHandledCounter.WithLabelValues("server_stream", "providers.openmetrics.testproto.v1.TestService", "PingList", "FailedPrecondition"))
+	requireValueHistCount(s.T(), 2, s.clientMetrics.clientHandledHistogram.WithLabelValues("server_stream", "providers.openmetrics.testproto.v1.TestService", "PingList"))
 }

--- a/providers/openmetrics/go.mod
+++ b/providers/openmetrics/go.mod
@@ -11,3 +11,5 @@ require (
 	google.golang.org/grpc v1.35.0
 	google.golang.org/protobuf v1.25.0
 )
+
+replace github.com/grpc-ecosystem/go-grpc-middleware/v2 => ../..

--- a/providers/openmetrics/go.sum
+++ b/providers/openmetrics/go.sum
@@ -72,7 +72,6 @@ github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/me
 github.com/gogo/googleapis v1.1.0/go.mod h1:gf4bu3Q80BeJ6H1S1vYPm8/ELATdvryBaNFGgqEef3s=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.0/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
-github.com/gogo/protobuf v1.2.1 h1:/s5zKNz0uPFCZ5hddgPdo2TK2TVrUNMn0OOX8/aZMTE=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
@@ -111,9 +110,6 @@ github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2z
 github.com/gorilla/websocket v0.0.0-20170926233335-4201258b820c/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de4 h1:z53tR0945TRRQO/fLEVPI6SMv7ZflF0TEaTAoU7tOzg=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de4/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
-github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.0.0-rc.2.0.20210128111500-3ff779b52992 h1:zQBrssA5h0QjXbr/d560qCC1L48fFjCxx6Ld1r4d+J4=
-github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.0.0-rc.2.0.20210128111500-3ff779b52992/go.mod h1:fG+XdHpfvMfdBQ9GTIRX0nXjb+VHaMWV5o9OCgw6Qi8=
-github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 h1:Ovs26xHkKqVztRpIrF/92BcuyuQ/YW4NSIpoGtfXNho=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.9.5/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/hashicorp/consul/api v1.3.0/go.mod h1:MmDNSzIMUjNpY/mQ398R4bk2FnqQLoPndWW5VkKPlCE=
@@ -271,7 +267,6 @@ github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
-github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
@@ -384,7 +379,6 @@ google.golang.org/genproto v0.0.0-20190307195333-5fe7a883aa19/go.mod h1:VzzqZJRn
 google.golang.org/genproto v0.0.0-20190425155659-357c62f0e4bb/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
 google.golang.org/genproto v0.0.0-20190530194941-fb225487d101/go.mod h1:z3L6/3dTEVtUr6QSP8miRzeRqwQOioJ9I66odjN4I7s=
 google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55/go.mod h1:DMBHOl98Agz4BDEuKkezgsaosCRResVns1a3J2ZsMNc=
-google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013 h1:+kGHl1aib/qcwaRi1CbqBZ1rk19r85MNUf8HaBghugY=
 google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013/go.mod h1:NbSheEEYHJ7i3ixzK3sjbqSGDJWnxyFXZblF3eUsNvo=
 google.golang.org/genproto v0.0.0-20200624020401-64a14ca9d1ad h1:uAwc13+y0Y8QZLTYhLCu6lHhnG99ecQU5FYTj8zxAng=
 google.golang.org/genproto v0.0.0-20200624020401-64a14ca9d1ad/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
@@ -432,7 +426,6 @@ gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.5/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/providers/openmetrics/options.go
+++ b/providers/openmetrics/options.go
@@ -36,6 +36,15 @@ func WithConstLabels(labels openmetrics.Labels) CounterOption {
 // funcs.
 type HistogramOption func(*openmetrics.HistogramOpts)
 
+type histogramOptions []HistogramOption
+
+func (ho histogramOptions) apply(o openmetrics.HistogramOpts) openmetrics.HistogramOpts {
+	for _, f := range ho {
+		f(&o)
+	}
+	return o
+}
+
 // WithHistogramBuckets allows you to specify custom bucket ranges for histograms if EnableHandlingTimeHistogram is on.
 func WithHistogramBuckets(buckets []float64) HistogramOption {
 	return func(o *openmetrics.HistogramOpts) { o.Buckets = buckets }

--- a/providers/openmetrics/server_interceptor.go
+++ b/providers/openmetrics/server_interceptor.go
@@ -1,35 +1,21 @@
 package metrics
 
 import (
-	openmetrics "github.com/prometheus/client_golang/prometheus"
 	"google.golang.org/grpc"
 
 	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors"
 )
 
-// RegisterServerMetrics returns a custom ServerMetrics object registered
-// with the user's registry, and registers some common metrics associated
-// with every instance.
-func RegisterServerMetrics(registry openmetrics.Registerer) *ServerMetrics {
-	customServerMetrics := NewServerMetrics(registry)
-	customServerMetrics.MustRegister(customServerMetrics.serverStartedCounter)
-	customServerMetrics.MustRegister(customServerMetrics.serverHandledCounter)
-	customServerMetrics.MustRegister(customServerMetrics.serverStreamMsgReceived)
-	customServerMetrics.MustRegister(customServerMetrics.serverStreamMsgSent)
-
-	return customServerMetrics
-}
-
 // UnaryServerInterceptor is a gRPC server-side interceptor that provides Prometheus monitoring for Unary RPCs.
-func UnaryServerInterceptor(serverRegister openmetrics.Registerer) grpc.UnaryServerInterceptor {
+func UnaryServerInterceptor(serverMetrics *ServerMetrics) grpc.UnaryServerInterceptor {
 	return interceptors.UnaryServerInterceptor(&reportable{
-		registry: serverRegister,
+		serverMetrics: serverMetrics,
 	})
 }
 
 // StreamServerInterceptor is a gRPC server-side interceptor that provides Prometheus monitoring for Streaming RPCs.
-func StreamServerInterceptor(serverRegister openmetrics.Registerer) grpc.StreamServerInterceptor {
+func StreamServerInterceptor(serverMetrics *ServerMetrics) grpc.StreamServerInterceptor {
 	return interceptors.StreamServerInterceptor(&reportable{
-		registry: serverRegister,
+		serverMetrics: serverMetrics,
 	})
 }

--- a/providers/openmetrics/server_metrics.go
+++ b/providers/openmetrics/server_metrics.go
@@ -2,92 +2,88 @@ package metrics
 
 import (
 	openmetrics "github.com/prometheus/client_golang/prometheus"
+	"google.golang.org/grpc"
 
 	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors"
-
-	"google.golang.org/grpc"
 )
 
 // ServerMetrics represents a collection of metrics to be registered on a
 // Prometheus metrics registry for a gRPC server.
 type ServerMetrics struct {
-	serverRegister openmetrics.Registerer
-
-	serverStartedCounter          *openmetrics.CounterVec
-	serverHandledCounter          *openmetrics.CounterVec
-	serverStreamMsgReceived       *openmetrics.CounterVec
-	serverStreamMsgSent           *openmetrics.CounterVec
-	serverHandledHistogramEnabled bool
-	serverHandledHistogramOpts    openmetrics.HistogramOpts
-	serverHandledHistogram        *openmetrics.HistogramVec
+	serverStartedCounter    *openmetrics.CounterVec
+	serverHandledCounter    *openmetrics.CounterVec
+	serverStreamMsgReceived *openmetrics.CounterVec
+	serverStreamMsgSent     *openmetrics.CounterVec
+	// serverHandledHistogram can be nil
+	serverHandledHistogram *openmetrics.HistogramVec
 }
 
-// NewServerMetrics returns a ServerMetrics object. Use a new instance of
-// ServerMetrics when not using the default Prometheus metrics registry, for
-// example when wanting to control which metrics are added to a registry as
-// opposed to automatically adding metrics via init functions.
-func NewServerMetrics(serverRegistry openmetrics.Registerer, counterOpts ...CounterOption) *ServerMetrics {
-	opts := counterOptions(counterOpts)
+// NewServerMetrics returns a new ServerMetrics object.
+func NewServerMetrics(opts ...ServerMetricsOption) *ServerMetrics {
+	var config serverMetricsConfig
+	config.apply(opts)
 	return &ServerMetrics{
-		serverRegister: serverRegistry,
 		serverStartedCounter: openmetrics.NewCounterVec(
-			opts.apply(openmetrics.CounterOpts{
+			config.counterOpts.apply(openmetrics.CounterOpts{
 				Name: "grpc_server_started_total",
 				Help: "Total number of RPCs started on the server.",
 			}), []string{"grpc_type", "grpc_service", "grpc_method"}),
 		serverHandledCounter: openmetrics.NewCounterVec(
-			opts.apply(openmetrics.CounterOpts{
+			config.counterOpts.apply(openmetrics.CounterOpts{
 				Name: "grpc_server_handled_total",
 				Help: "Total number of RPCs completed on the server, regardless of success or failure.",
 			}), []string{"grpc_type", "grpc_service", "grpc_method", "grpc_code"}),
 		serverStreamMsgReceived: openmetrics.NewCounterVec(
-			opts.apply(openmetrics.CounterOpts{
+			config.counterOpts.apply(openmetrics.CounterOpts{
 				Name: "grpc_server_msg_received_total",
 				Help: "Total number of RPC stream messages received on the server.",
 			}), []string{"grpc_type", "grpc_service", "grpc_method"}),
 		serverStreamMsgSent: openmetrics.NewCounterVec(
-			opts.apply(openmetrics.CounterOpts{
+			config.counterOpts.apply(openmetrics.CounterOpts{
 				Name: "grpc_server_msg_sent_total",
 				Help: "Total number of gRPC stream messages sent by the server.",
 			}), []string{"grpc_type", "grpc_service", "grpc_method"}),
-		serverHandledHistogramEnabled: false,
-		serverHandledHistogramOpts: openmetrics.HistogramOpts{
-			Name:    "grpc_server_handling_seconds",
-			Help:    "Histogram of response latency (seconds) of gRPC that had been application-level handled by the server.",
-			Buckets: openmetrics.DefBuckets,
-		},
-		serverHandledHistogram: nil,
+		serverHandledHistogram: config.serverHandledHistogram,
 	}
 }
 
-// Register registers the provided Collector with the custom register.
+// NewRegisteredServerMetrics returns a custom ServerMetrics object registered
+// with the user's registry, and registers some common metrics associated
+// with every instance.
+func NewRegisteredServerMetrics(registry openmetrics.Registerer, opts ...ServerMetricsOption) *ServerMetrics {
+	customServerMetrics := NewServerMetrics(opts...)
+	customServerMetrics.MustRegister(registry)
+	return customServerMetrics
+}
+
+// Register registers the metrics with the registry.
 // returns error much like DefaultRegisterer of Prometheus.
-func (m *ServerMetrics) Register(c openmetrics.Collector) error {
-	return m.serverRegister.Register(c)
+func (m *ServerMetrics) Register(registry openmetrics.Registerer) error {
+	for _, collector := range m.toRegister() {
+		if err := registry.Register(collector); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
-// MustRegister registers the provided Collectors with the custom Registerer
+// MustRegister registers the metrics with the registry
 // and panics if any error occurs much like DefaultRegisterer of Prometheus.
-func (m *ServerMetrics) MustRegister(c openmetrics.Collector) {
-	m.serverRegister.MustRegister(c)
+func (m *ServerMetrics) MustRegister(registry openmetrics.Registerer) {
+	registry.MustRegister(m.toRegister()...)
 }
 
-// EnableHandlingTimeHistogram turns on recording of handling time
-// of RPCs. Histogram metrics can be very expensive for Prometheus
-// to retain and query.It takes options to configure histogram
-// options such as the defined buckets.
-func (m *ServerMetrics) EnableHandlingTimeHistogram(opts ...HistogramOption) error {
-	for _, o := range opts {
-		o(&m.serverHandledHistogramOpts)
+func (m *ServerMetrics) toRegister() []openmetrics.Collector {
+	res := []openmetrics.Collector{
+		m.serverStartedCounter,
+		m.serverHandledCounter,
+		m.serverStreamMsgReceived,
+		m.serverStreamMsgSent,
 	}
-	if !m.serverHandledHistogramEnabled {
-		m.serverHandledHistogram = openmetrics.NewHistogramVec(
-			m.serverHandledHistogramOpts,
-			[]string{"grpc_type", "grpc_service", "grpc_method"},
-		)
+	if m.serverHandledHistogram != nil {
+		res = append(res, m.serverHandledHistogram)
 	}
-	m.serverHandledHistogramEnabled = true
-	return m.serverRegister.Register(m.serverHandledHistogram)
+	return res
 }
 
 // Describe sends the super-set of all possible descriptors of metrics
@@ -98,7 +94,7 @@ func (m *ServerMetrics) Describe(ch chan<- *openmetrics.Desc) {
 	m.serverHandledCounter.Describe(ch)
 	m.serverStreamMsgReceived.Describe(ch)
 	m.serverStreamMsgSent.Describe(ch)
-	if m.serverHandledHistogramEnabled {
+	if m.serverHandledHistogram != nil {
 		m.serverHandledHistogram.Describe(ch)
 	}
 }
@@ -111,7 +107,7 @@ func (m *ServerMetrics) Collect(ch chan<- openmetrics.Metric) {
 	m.serverHandledCounter.Collect(ch)
 	m.serverStreamMsgReceived.Collect(ch)
 	m.serverStreamMsgSent.Collect(ch)
-	if m.serverHandledHistogramEnabled {
+	if m.serverHandledHistogram != nil {
 		m.serverHandledHistogram.Collect(ch)
 	}
 }
@@ -136,7 +132,7 @@ func (m *ServerMetrics) preRegisterMethod(serviceName string, mInfo *grpc.Method
 	m.serverStartedCounter.GetMetricWithLabelValues(methodType, serviceName, methodName)
 	m.serverStreamMsgReceived.GetMetricWithLabelValues(methodType, serviceName, methodName)
 	m.serverStreamMsgSent.GetMetricWithLabelValues(methodType, serviceName, methodName)
-	if m.serverHandledHistogramEnabled {
+	if m.serverHandledHistogram != nil {
 		m.serverHandledHistogram.GetMetricWithLabelValues(methodType, serviceName, methodName)
 	}
 	for _, code := range interceptors.AllCodes {

--- a/providers/openmetrics/server_options.go
+++ b/providers/openmetrics/server_options.go
@@ -1,0 +1,40 @@
+package metrics
+
+import (
+	openmetrics "github.com/prometheus/client_golang/prometheus"
+)
+
+type serverMetricsConfig struct {
+	counterOpts counterOptions
+	// serverHandledHistogram can be nil
+	serverHandledHistogram *openmetrics.HistogramVec
+}
+
+type ServerMetricsOption func(*serverMetricsConfig)
+
+func (c *serverMetricsConfig) apply(opts []ServerMetricsOption) {
+	for _, o := range opts {
+		o(c)
+	}
+}
+
+func WithServerCounterOptions(opts ...CounterOption) ServerMetricsOption {
+	return func(o *serverMetricsConfig) {
+		o.counterOpts = opts
+	}
+}
+
+// WithServerHandlingTimeHistogram turns on recording of handling time of RPCs.
+// Histogram metrics can be very expensive for Prometheus to retain and query.
+func WithServerHandlingTimeHistogram(opts ...HistogramOption) ServerMetricsOption {
+	return func(o *serverMetricsConfig) {
+		o.serverHandledHistogram = openmetrics.NewHistogramVec(
+			histogramOptions(opts).apply(openmetrics.HistogramOpts{
+				Name:    "grpc_server_handling_seconds",
+				Help:    "Histogram of response latency (seconds) of gRPC that had been application-level handled by the server.",
+				Buckets: openmetrics.DefBuckets,
+			}),
+			[]string{"grpc_type", "grpc_service", "grpc_method"},
+		)
+	}
+}


### PR DESCRIPTION
I decided to have a look at the v2 branch as I'm interested in better Prometheus metrics. I found that stuff was in a very weird state so I tried to fix, simplify and clean it all up. See inline comments for some details. I have also found that tests fail and are not executed on macOS (https://github.com/grpc-ecosystem/go-grpc-middleware/issues/411).

Closes https://github.com/grpc-ecosystem/go-grpc-middleware/issues/412.