### PR TITLE
validator: add support for protoc-gen-validate 0.6.0

### DIFF
--- a/testing/testproto/test.manual_validator.pb.go
+++ b/testing/testproto/test.manual_validator.pb.go
@@ -15,7 +15,7 @@ func (p *PingRequest) Validate() error {
 	return nil
 }
 
-// Implements the new validation interface from protoc-genvalidate.
+// Implements the new validation interface from protoc-gen-validate.
 func (p *PingResponse) Validate(bool) error {
 	if p.Counter > math.MaxInt16 {
 		return errors.New("ping allocation exceeded")

--- a/testing/testproto/test.manual_validator.pb.go
+++ b/testing/testproto/test.manual_validator.pb.go
@@ -2,11 +2,23 @@
 
 package mwitkow_testproto
 
-import "errors"
+import (
+	"errors"
+	"math"
+)
 
+// Implements the legacy validation interface from protoc-gen-validate.
 func (p *PingRequest) Validate() error {
 	if p.SleepTimeMs > 10000 {
 		return errors.New("cannot sleep for more than 10s")
+	}
+	return nil
+}
+
+// Implements the new validation interface from protoc-genvalidate.
+func (p *PingResponse) Validate(bool) error {
+	if p.Counter > math.MaxInt16 {
+		return errors.New("ping allocation exceeded")
 	}
 	return nil
 }


### PR DESCRIPTION
https://github.com/envoyproxy/protoc-gen-validate/pull/455 changed the interface for the `Validate` call from `Validate()` to `Validate(bool)`.

I modified the middleware to support both.