### PR TITLE
v2:providers/zap: fix caller annotation

### DIFF
--- a/providers/zap/logger.go
+++ b/providers/zap/logger.go
@@ -25,13 +25,13 @@ func InterceptorLogger(logger *zap.Logger) *Logger {
 func (l *Logger) Log(lvl logging.Level, msg string) {
 	switch lvl {
 	case logging.DEBUG:
-		l.Debug(msg)
+		l.WithOptions(zap.AddCallerSkip(1)).Debug(msg)
 	case logging.INFO:
-		l.Info(msg)
+		l.WithOptions(zap.AddCallerSkip(1)).Info(msg)
 	case logging.WARNING:
-		l.Warn(msg)
+		l.WithOptions(zap.AddCallerSkip(1)).Warn(msg)
 	case logging.ERROR:
-		l.Error(msg)
+		l.WithOptions(zap.AddCallerSkip(1)).Error(msg)
 	default:
 		panic(fmt.Sprintf("zap: unknown level %s", lvl))
 	}

--- a/providers/zap/logger_test.go
+++ b/providers/zap/logger_test.go
@@ -1,0 +1,36 @@
+package zap
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/logging"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest"
+)
+
+func TestLogger_Log(t *testing.T) {
+	msg := "message"
+
+	levels := []logging.Level{logging.DEBUG, logging.INFO, logging.WARNING, logging.ERROR}
+	for _, level := range levels {
+		called := false
+		logger := InterceptorLogger(zaptest.NewLogger(t, zaptest.WrapOptions(zap.Hooks(func(entry zapcore.Entry) error {
+			called = true
+
+			if entry.Message != msg {
+				t.Errorf("expect %v, got %v", msg, entry.Message)
+			}
+			if _, file, _, _ := runtime.Caller(0); entry.Caller.File != file {
+				t.Errorf("caller: expected %v, got %v", file, entry.Caller.File)
+			}
+			return nil
+		}), zap.AddCaller())))
+
+		logger.Log(level, msg)
+		if !called {
+			t.Error("hook isn't called")
+		}
+	}
+}


### PR DESCRIPTION
`Logger.Log` calls a zap's log function inside of this function. As a result, caller annotations always point `zap/logger.go`. This commit adds caller skip so that each log message has the correct annotation.