### PR TITLE
v2:interceptors/logging: allow to separate request response payload logging

### DIFF
--- a/interceptors/logging/logging.go
+++ b/interceptors/logging/logging.go
@@ -67,15 +67,29 @@ func DefaultDeciderMethod(_ string, _ error) Decision {
 	return LogStartAndFinishCall
 }
 
+// PayloadDecision defines rules for enabling payload logging of request and responses.
+type PayloadDecision int
+
+const (
+	// NoPayloadLogging - Payload logging is disabled.
+	NoPayloadLogging PayloadDecision = iota
+	// LogPayloadRequest - Only logging of requests is enabled.
+	LogPayloadRequest
+	// LogPayloadResponse - Only logging of responses is enabled.
+	LogPayloadResponse
+	// LogPayloadRequestAndResponse - Logging of both requests and responses is enabled.
+	LogPayloadRequestAndResponse
+)
+
 // ServerPayloadLoggingDecider is a user-provided function for deciding whether to log the server-side
 // request/response payloads
-type ServerPayloadLoggingDecider func(ctx context.Context, fullMethodName string, servingObject interface{}) bool
+type ServerPayloadLoggingDecider func(ctx context.Context, fullMethodName string, servingObject interface{}) PayloadDecision
 
 // ClientPayloadLoggingDecider is a user-provided function for deciding whether to log the client-side
 // request/response payloads
-type ClientPayloadLoggingDecider func(ctx context.Context, fullMethodName string) bool
+type ClientPayloadLoggingDecider func(ctx context.Context, fullMethodName string) PayloadDecision
 
-// JsonPbMarshaller is a marshaller that serializes protobuf messages.
+// JsonPbMarshaler is a marshaller that serializes protobuf messages.
 type JsonPbMarshaler interface {
 	Marshal(pb proto.Message) ([]byte, error)
 }

--- a/interceptors/logging/payload_test.go
+++ b/interceptors/logging/payload_test.go
@@ -27,8 +27,12 @@ type loggingPayloadSuite struct {
 }
 
 func TestPayloadSuite(t *testing.T) {
-	alwaysLoggingDeciderServer := func(ctx context.Context, fullMethodName string, servingObject interface{}) bool { return true }
-	alwaysLoggingDeciderClient := func(ctx context.Context, fullMethodName string) bool { return true }
+	alwaysLoggingDeciderServer := func(context.Context, string, interface{}) logging.PayloadDecision {
+		return logging.LogPayloadRequestAndResponse
+	}
+	alwaysLoggingDeciderClient := func(context.Context, string) logging.PayloadDecision {
+		return logging.LogPayloadRequestAndResponse
+	}
 
 	s := &loggingPayloadSuite{
 		baseLoggingSuite: &baseLoggingSuite{


### PR DESCRIPTION
Logging payloads of requests on the server-side and similarly of responses on the client-side is a pretty common and desired use-case. However, logging by default payloads of both requests as well as responses in both scenarios is IMO not a very common requirement.

Consider the following PR to enable more granular control of what to log and when. This is achieved by using a special `PayloadDecison` type having the following values:
* `NoPayloadLogging` - Payload logging is disabled.
* `LogRequest` - Only logging of requests is enabled.
* `LogResponse` - Only logging of responses is enabled.
* `LogRequestAndResponse` - Logging of both requests and responses is enabled.
The `PayloadDecison` is to be used instead of the original `bool` by the `logging.ServerPayloadLoggingDecider` and `logging.ClientPayloadLoggingDecider`.

NOTE: I quickly put this together to see whether it could be considered a valid approach, thus please excuse the lack of additional unit tests. I will be glad to add those once the approach is approved.