### PR TITLE
Doc Fix: middleware chain order example

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,20 +29,20 @@ import "github.com/grpc-ecosystem/go-grpc-middleware"
 
 myServer := grpc.NewServer(
     grpc.StreamInterceptor(grpc_middleware.ChainStreamServer(
-        grpc_recovery.StreamServerInterceptor(),
         grpc_ctxtags.StreamServerInterceptor(),
         grpc_opentracing.StreamServerInterceptor(),
         grpc_prometheus.StreamServerInterceptor,
         grpc_zap.StreamServerInterceptor(zapLogger),
         grpc_auth.StreamServerInterceptor(myAuthFunction),
+        grpc_recovery.StreamServerInterceptor(),
     )),
     grpc.UnaryInterceptor(grpc_middleware.ChainUnaryServer(
-        grpc_recovery.UnaryServerInterceptor(),
         grpc_ctxtags.UnaryServerInterceptor(),
         grpc_opentracing.UnaryServerInterceptor(),
         grpc_prometheus.UnaryServerInterceptor,
         grpc_zap.UnaryServerInterceptor(zapLogger),
         grpc_auth.UnaryServerInterceptor(myAuthFunction),
+        grpc_recovery.UnaryServerInterceptor(),
     )),
 )
 ```


### PR DESCRIPTION
In the chaining interceptor example, the recovery handler was the first element in the unary chain. It should have been last as per the recovery example in the codebase.

https://github.com/grpc-ecosystem/go-grpc-middleware/blob/b6d97fab8b7d7d99cb5a9ee1ea17afbb2b12e84c/recovery/examples_test.go#L28
https://github.com/grpc-ecosystem/go-grpc-middleware/blob/b6d97fab8b7d7d99cb5a9ee1ea17afbb2b12e84c/recovery/examples_test.go#L29