### PR TITLE
Replace two old Go versions with two new ones

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -30,11 +30,11 @@ jobs:
 
   tests:
     runs-on: ${{ matrix.platform }}
-    name: Unit tests on Go ${{ matrix.go }}
+    name: Unit tests on Go ${{ matrix.go }} / ${{ matrix.platform }}
     strategy:
       fail-fast: false
       matrix:
-        go: [ '1.13.x', '1.14.x', '1.15.x' ]
+        go: [ '1.15.x', '1.16.x', '1.17.x' ]
         platform: [ubuntu-latest, macos-latest]
     steps:
       - name: Checkout code into the Go module directory.


### PR DESCRIPTION
The test matrix for this repository is missing the two newest Go versions. This PR adds them, removing the two oldest ones, in order to keep the CI cycle times reasonable.

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>
