### PR TITLE
Remove data race from zerolog provider

### DIFF
--- a/providers/zerolog/logger.go
+++ b/providers/zerolog/logger.go
@@ -16,26 +16,25 @@ var _ logging.Logger = &Logger{}
 
 // Logger is a zerolog logging adapter compatible with logging middlewares.
 type Logger struct {
-	zerolog.Context
+	zerolog.Logger
 }
 
 // InterceptorLogger is a zerolog.Logger to Logger adapter.
 func InterceptorLogger(logger zerolog.Logger) *Logger {
-	return &Logger{logger.With()}
+	return &Logger{logger}
 }
 
 // Log implements the logging.Logger interface.
 func (l *Logger) Log(lvl logging.Level, msg string) {
-	cl := l.Logger()
 	switch lvl {
 	case logging.DEBUG:
-		cl.Debug().Msg(msg)
+		l.Debug().Msg(msg)
 	case logging.INFO:
-		cl.Info().Msg(msg)
+		l.Info().Msg(msg)
 	case logging.WARNING:
-		cl.Warn().Msg(msg)
+		l.Warn().Msg(msg)
 	case logging.ERROR:
-		cl.Error().Msg(msg)
+		l.Error().Msg(msg)
 	default:
 		// TODO(kb): Perhaps this should be a logged warning, defaulting to ERROR to get attention
 		// without interrupting code flow?
@@ -44,10 +43,10 @@ func (l *Logger) Log(lvl logging.Level, msg string) {
 }
 
 // With implements the logging.Logger interface.
-func (l *Logger) With(fields ...string) logging.Logger {
+func (l Logger) With(fields ...string) logging.Logger {
 	vals := make(map[string]interface{}, len(fields)/2)
 	for i := 0; i < len(fields); i += 2 {
 		vals[fields[i]] = fields[i+1]
 	}
-	return InterceptorLogger(l.Fields(vals).Logger())
+	return InterceptorLogger(l.Logger.With().Fields(vals).Logger())
 }


### PR DESCRIPTION
It's important that `With()` on the adapter call `With()` on zerolog each time, so that we get a copy of the zerolog logger. 

The zerolog logger [isn't threadsafe by default](https://github.com/rs/zerolog/issues/242#issuecomment-915611449)

Here's an old test run showing the race: 

https://github.com/authzed/spicedb/runs/5382249173?check_suite_focus=true
```
WARNING: DATA RACE
Write at 0x00c0008b0206 by goroutine 110:
  runtime.slicecopy()
      /opt/hostedtoolcache/go/1.17.7/x64/src/runtime/slice.go:284 +0x0
  github.com/rs/zerolog/internal/json.Encoder.AppendString()
      /home/runner/go/pkg/mod/github.com/rs/zerolog@v1.26.1/internal/json/string.go:61 +0x250
  github.com/rs/zerolog/internal/json.Encoder.AppendKey()
      /home/runner/go/pkg/mod/github.com/rs/zerolog@v1.26.1/internal/json/base.go:18 +0x304
  github.com/rs/zerolog.appendFieldList()
      /home/runner/go/pkg/mod/github.com/rs/zerolog@v1.26.1/fields.go:41 +0x20d
  github.com/rs/zerolog.appendFields()
      /home/runner/go/pkg/mod/github.com/rs/zerolog@v1.26.1/fields.go:31 +0x504
  github.com/rs/zerolog.Context.Fields()
      /home/runner/go/pkg/mod/github.com/rs/zerolog@v1.26.1/context.go:25 +0x25b
  github.com/grpc-ecosystem/go-grpc-middleware/providers/zerolog/v2.(*Logger).With()
      /home/runner/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware/providers/zerolog/v2@v2.0.0-rc.2.0.20210831071041-dd1540ef8252/logger.go:52 +0x1f8
  github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/logging.reportable.func1()
      /home/runner/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware/v2@v2.0.0-rc.2.0.20210831071041-dd1540ef8252/interceptors/logging/interceptors.go:96 +0xb12
  github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors.CommonReportableFunc.ServerReporter()
      /home/runner/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware/v2@v2.0.0-rc.2.0.20210831071041-dd1540ef8252/interceptors/reporter.go:85 +0x91
  github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors.UnaryServerInterceptor.func1()
      /home/runner/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware/v2@v2.0.0-rc.2.0.20210831071041-dd1540ef8252/interceptors/server.go:19 +0x24c
  google.golang.org/grpc.chainUnaryInterceptors.func1.1()
      /home/runner/go/pkg/mod/google.golang.org/grpc@v1.44.0/server.go:1119 +0x226
  github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors.UnaryServerInterceptor.func1()
      /home/runner/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware/v2@v2.0.0-rc.2.0.20210831071041-dd1540ef8252/interceptors/server.go:22 +0x2e3
  google.golang.org/grpc.chainUnaryInterceptors.func1.1()
      /home/runner/go/pkg/mod/google.golang.org/grpc@v1.44.0/server.go:1119 +0x226
  github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors.UnaryServerInterceptor.func1()
      /home/runner/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware/v2@v2.0.0-rc.2.0.20210831071041-dd1540ef8252/interceptors/server.go:22 +0x2e3
  google.golang.org/grpc.chainUnaryInterceptors.func1.1()
      /home/runner/go/pkg/mod/google.golang.org/grpc@v1.44.0/server.go:1119 +0x226
  google.golang.org/grpc.chainUnaryInterceptors.func1()
      /home/runner/go/pkg/mod/google.golang.org/grpc@v1.44.0/server.go:1121 +0x285
  github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func1.1.1()
      /home/runner/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.3.0/chain.go:25 +0x8e
  github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func1()
      /home/runner/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.3.0/chain.go:34 +0x126
  github.com/authzed/spicedb/pkg/proto/dispatch/v1._DispatchService_DispatchLookup_Handler()
      /home/runner/work/spicedb/spicedb/pkg/proto/dispatch/v1/dispatch_grpc.pb.go:148 +0x1da
  github.com/authzed/grpcutil.WrapMethods.func1()
      /home/runner/go/pkg/mod/github.com/authzed/grpcutil@v0.0.0-20220104222419-f813f77722e5/middleware.go:67 +0x12e
  google.golang.org/grpc.(*Server).processUnaryRPC()
      /home/runner/go/pkg/mod/google.golang.org/grpc@v1.44.0/server.go:1282 +0x1514
  google.golang.org/grpc.(*Server).handleStream()
      /home/runner/go/pkg/mod/google.golang.org/grpc@v1.44.0/server.go:1616 +0xfd3
  google.golang.org/grpc.(*Server).serveStreams.func1.2()
      /home/runner/go/pkg/mod/google.golang.org/grpc@v1.44.0/server.go:921 +0xfd

Previous write at 0x00c0008b0206 by goroutine 77:
  runtime.slicecopy()
      /opt/hostedtoolcache/go/1.17.7/x64/src/runtime/slice.go:284 +0x0
  github.com/rs/zerolog/internal/json.Encoder.AppendString()
      /home/runner/go/pkg/mod/github.com/rs/zerolog@v1.26.1/internal/json/string.go:61 +0x250
  github.com/rs/zerolog/internal/json.Encoder.AppendKey()
      /home/runner/go/pkg/mod/github.com/rs/zerolog@v1.26.1/internal/json/base.go:18 +0x304
  github.com/rs/zerolog.appendFieldList()
      /home/runner/go/pkg/mod/github.com/rs/zerolog@v1.26.1/fields.go:41 +0x20d
  github.com/rs/zerolog.appendFields()
      /home/runner/go/pkg/mod/github.com/rs/zerolog@v1.26.1/fields.go:31 +0x504
  github.com/rs/zerolog.Context.Fields()
      /home/runner/go/pkg/mod/github.com/rs/zerolog@v1.26.1/context.go:25 +0x25b
  github.com/grpc-ecosystem/go-grpc-middleware/providers/zerolog/v2.(*Logger).With()
      /home/runner/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware/providers/zerolog/v2@v2.0.0-rc.2.0.20210831071041-dd1540ef8252/logger.go:52 +0x1f8
  github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/logging.reportable.func1()
      /home/runner/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware/v2@v2.0.0-rc.2.0.20210831071041-dd1540ef8252/interceptors/logging/interceptors.go:96 +0xb12
  github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors.CommonReportableFunc.ServerReporter()
      /home/runner/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware/v2@v2.0.0-rc.2.0.20210831071041-dd1540ef8252/interceptors/reporter.go:85 +0x91
  github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors.UnaryServerInterceptor.func1()
      /home/runner/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware/v2@v2.0.0-rc.2.0.20210831071041-dd1540ef8252/interceptors/server.go:19 +0x24c
  google.golang.org/grpc.chainUnaryInterceptors.func1.1()
      /home/runner/go/pkg/mod/google.golang.org/grpc@v1.44.0/server.go:1119 +0x226
  github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors.UnaryServerInterceptor.func1()
      /home/runner/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware/v2@v2.0.0-rc.2.0.20210831071041-dd1540ef8252/interceptors/server.go:22 +0x2e3
  google.golang.org/grpc.chainUnaryInterceptors.func1.1()
      /home/runner/go/pkg/mod/google.golang.org/grpc@v1.44.0/server.go:1119 +0x226
  github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors.UnaryServerInterceptor.func1()
      /home/runner/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware/v2@v2.0.0-rc.2.0.20210831071041-dd1540ef8252/interceptors/server.go:22 +0x2e3
  google.golang.org/grpc.chainUnaryInterceptors.func1.1()
      /home/runner/go/pkg/mod/google.golang.org/grpc@v1.44.0/server.go:1119 +0x226
  google.golang.org/grpc.chainUnaryInterceptors.func1()
      /home/runner/go/pkg/mod/google.golang.org/grpc@v1.44.0/server.go:1121 +0x285
  github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func1.1.1()
      /home/runner/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.3.0/chain.go:25 +0x8e
  github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func1()
      /home/runner/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.3.0/chain.go:34 +0x126
  github.com/authzed/spicedb/pkg/proto/dispatch/v1._DispatchService_DispatchLookup_Handler()
      /home/runner/work/spicedb/spicedb/pkg/proto/dispatch/v1/dispatch_grpc.pb.go:148 +0x1da
  github.com/authzed/grpcutil.WrapMethods.func1()
      /home/runner/go/pkg/mod/github.com/authzed/grpcutil@v0.0.0-20220104222419-f813f77722e5/middleware.go:67 +0x12e
  google.golang.org/grpc.(*Server).processUnaryRPC()
      /home/runner/go/pkg/mod/google.golang.org/grpc@v1.44.0/server.go:1282 +0x1514
  google.golang.org/grpc.(*Server).handleStream()
      /home/runner/go/pkg/mod/google.golang.org/grpc@v1.44.0/server.go:1616 +0xfd3
  google.golang.org/grpc.(*Server).serveStreams.func1.2()
      /home/runner/go/pkg/mod/google.golang.org/grpc@v1.44.0/server.go:921 +0xfd
```

And a newer run (using a local copy of the file in this PR):
https://github.com/authzed/spicedb/runs/5450521332?check_suite_focus=true

Open to discussing other options to address this, but this seemed the most straightforward.