### PR TITLE
Fix memory leakage in kit.PayloadUnaryServerInterceptor memory leakage

### DIFF
--- a/logging/kit/payload_interceptors.go
+++ b/logging/kit/payload_interceptors.go
@@ -31,8 +31,8 @@ func PayloadUnaryServerInterceptor(logger log.Logger, decider grpc_logging.Serve
 			return handler(ctx, req)
 		}
 		// Use the provided log.Logger for logging but use the fields from context.
-		logger = log.With(logger, append(serverCallFields(info.FullMethod), ctxkit.TagsToFields(ctx)...)...)
-		logProtoMessageAsJson(logger, req, "grpc.request.content", "server request payload logged as grpc.request.content field")
+		logEntry := log.With(logger, append(serverCallFields(info.FullMethod), ctxkit.TagsToFields(ctx)...)...)
+		logProtoMessageAsJson(logEntry, req, "grpc.request.content", "server request payload logged as grpc.request.content field")
 		resp, err := handler(ctx, req)
 		if err == nil {
 			logProtoMessageAsJson(logger, resp, "grpc.response.content", "server response payload logged as grpc.request.content field")


### PR DESCRIPTION
Closes issue #498

A wrong assign creates multiple object for GC, and with every call appends new objects, so GC have to walk through thousands of objects. This causes high increasing memory and CPU usage. We saw in our services that it leads to CPU throttling and increasing of a memory usage.