### PR TITLE
Use %+v to store the error

### DIFF
--- a/logging/logrus/options.go
+++ b/logging/logrus/options.go
@@ -5,6 +5,7 @@ package grpc_logrus
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	grpc_logging "github.com/grpc-ecosystem/go-grpc-middleware/logging"
@@ -210,7 +211,7 @@ type MessageProducer func(ctx context.Context, format string, level logrus.Level
 // DefaultMessageProducer writes the default message
 func DefaultMessageProducer(ctx context.Context, format string, level logrus.Level, code codes.Code, err error, fields logrus.Fields) {
 	if err != nil {
-		fields[logrus.ErrorKey] = err
+		fields[logrus.ErrorKey] = fmt.Sprintf("%+v", err)
 	}
 	entry := ctxlogrus.Extract(ctx).WithContext(ctx).WithFields(fields)
 	switch level {

--- a/logging/logrus/server_interceptors.go
+++ b/logging/logrus/server_interceptors.go
@@ -4,6 +4,7 @@ package grpc_logrus
 
 import (
 	"context"
+	"fmt"
 	"path"
 	"time"
 
@@ -41,7 +42,7 @@ func UnaryServerInterceptor(entry *logrus.Entry, opts ...Option) grpc.UnaryServe
 			durField:    durVal,
 		}
 		if err != nil {
-			fields[logrus.ErrorKey] = err
+			fields[logrus.ErrorKey] = fmt.Sprintf("%+v", err)
 		}
 
 		o.messageFunc(newCtx, "finished unary call with code "+code.String(), level, code, err, fields)

--- a/logging/logrus/shared_test.go
+++ b/logging/logrus/shared_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"testing"
 
@@ -107,7 +108,7 @@ func (s *logrusBaseSuite) getOutputJSONs() []map[string]interface{} {
 
 func StubMessageProducer(ctx context.Context, format string, level logrus.Level, code codes.Code, err error, fields logrus.Fields) {
 	if err != nil {
-		fields[logrus.ErrorKey] = err
+		fields[logrus.ErrorKey] = fmt.Sprintf("%+v", err)
 	}
 	format = "custom message"
 	entry := ctxlogrus.Extract(ctx).WithContext(ctx).WithFields(fields)


### PR DESCRIPTION
Using `%+v` to store the error allows to print stacktrace along with the error message, if errors are constructed using the `github.com/pkg/errors package`. See https://dave.cheney.net/2016/06/12/stack-traces-and-the-errors-package for more details.

If error is created using `errors` package, it works as is and has no impact in behavior.

Maintainers - Let me know if you have some other suggestions.