### PR TITLE
use idiomatic pointer safing for zap.Check

### DIFF
--- a/logging/zap/options.go
+++ b/logging/zap/options.go
@@ -209,9 +209,11 @@ type MessageProducer func(ctx context.Context, msg string, level zapcore.Level, 
 // DefaultMessageProducer writes the default message
 func DefaultMessageProducer(ctx context.Context, msg string, level zapcore.Level, code codes.Code, err error, duration zapcore.Field) {
 	// re-extract logger from newCtx, as it may have extra fields that changed in the holder.
-	ctxzap.Extract(ctx).Check(level, msg).Write(
-		zap.Error(err),
-		zap.String("grpc.code", code.String()),
-		duration,
-	)
+	if ce := ctxzap.Extract(ctx).Check(level, msg); ce != nil {
+		ce.Write(
+			zap.Error(err),
+			zap.String("grpc.code", code.String()),
+			duration,
+		)
+	} /* TODO(ermik): else ? */
 }


### PR DESCRIPTION
Call to zap.Logger Check method is a proxy to internal [check][1] which can return nil. Looking at the way Uber's own code, they use the idiomatic pointer safing before continuing past that call.

If accepted, this commit should be a bug fix to all actively maintained versions.

[1]: https://github.com/uber-go/zap/blob/v1.18.1/logger.go#L261