### PR TITLE
fix: iter would no longer be inited every time in the loop

### DIFF
--- a/interceptors/logging/examples/zap/example_test.go
+++ b/interceptors/logging/examples/zap/example_test.go
@@ -17,10 +17,10 @@ import (
 func InterceptorLogger(l *zap.Logger) logging.Logger {
 	return logging.LoggerFunc(func(ctx context.Context, lvl logging.Level, msg string, fields ...any) {
 		f := make([]zap.Field, 0, len(fields)/2)
+		iter := logging.Fields(fields).Iterator()
 		for i := 0; i < len(fields); i += 2 {
-			i := logging.Fields(fields).Iterator()
-			if i.Next() {
-				k, v := i.At()
+			if iter.Next() {
+				k, v := iter.At()
 				f = append(f, zap.Any(k, v))
 			}
 		}


### PR DESCRIPTION
<!--
    Keep PR title verbose enough.
-->
fix: iter would no longer be inited every time in the loop

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/grpc-ecosystem/go-grpc-middleware/pull/<PR-id>
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
I've used this code in my project, and the log looks good now
