### PR TITLE
fix: correct example to avoid zerolog fields combined

### DIFF
--- a/interceptors/logging/examples/zerolog/example_test.go
+++ b/interceptors/logging/examples/zerolog/example_test.go
@@ -17,17 +17,17 @@ import (
 // This code is simple enough to be copied and not imported.
 func InterceptorLogger(l zerolog.Logger) logging.Logger {
 	return logging.LoggerFunc(func(ctx context.Context, lvl logging.Level, msg string, fields ...any) {
-		l = l.With().Fields(fields).Logger()
+		log := l.With().Fields(fields).Logger()
 
 		switch lvl {
 		case logging.LevelDebug:
-			l.Debug().Msg(msg)
+			log.Debug().Msg(msg)
 		case logging.LevelInfo:
-			l.Info().Msg(msg)
+			log.Info().Msg(msg)
 		case logging.LevelWarn:
-			l.Warn().Msg(msg)
+			log.Warn().Msg(msg)
 		case logging.LevelError:
-			l.Error().Msg(msg)
+			log.Error().Msg(msg)
 		default:
 			panic(fmt.Sprintf("unknown level %v", lvl))
 		}


### PR DESCRIPTION
I follow the current code in the example of using `zerolog` and `fields` grown after each request. It combines all `fields` to the context of `l` after each request and makes the log messages become huge. 
It's the same with this issue on `zap` https://github.com/grpc-ecosystem/go-grpc-middleware/issues/559

<img width="1232" alt="image" src="https://user-images.githubusercontent.com/9171324/232299311-822ff337-0401-4296-a2c5-5bf36bf66b62.png">


I fixed this by creating a new instance of `zerolog.Logger` instead of using `l` and it works like a charm. 

<img width="986" alt="image" src="https://user-images.githubusercontent.com/9171324/232299730-00938c0e-ae88-4e2e-88d0-787344b49b4f.png">


* [x] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

* [x] Correct example of `interceptors/logging/examples/zerolog`

## Verification

I tested and it works on my project, logs work fine and didn't get combined `fields`
