### PR TITLE
fix prometheus interceptors not converting context errors to gRPC codes

### DIFF
--- a/providers/prometheus/options.go
+++ b/providers/prometheus/options.go
@@ -9,11 +9,15 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-// FromError returns a grpc status if error code is a valid grpc status.
-func FromError(err error) (s *status.Status, ok bool) {
-	return status.FromError(err)
-
-	// TODO: @yashrsharma44 - discuss if we require more error handling from the previous package
+// FromError returns a grpc status. If the error code is neither a valid grpc status nor a context error, codes.Unknown
+// will be set.
+func FromError(err error) *status.Status {
+	s, ok := status.FromError(err)
+	// Mirror what the grpc server itself does, i.e. also convert context errors to status
+	if !ok {
+		s = status.FromContextError(err)
+	}
+	return s
 }
 
 // A CounterOption lets you add options to Counter metrics using With* funcs.

--- a/providers/prometheus/reporter.go
+++ b/providers/prometheus/reporter.go
@@ -22,7 +22,7 @@ type reporter struct {
 
 func (r *reporter) PostCall(err error, rpcDuration time.Duration) {
 	// get status code from error
-	status, _ := FromError(err)
+	status := FromError(err)
 	code := status.Code()
 
 	// perform handling of metrics from code


### PR DESCRIPTION
First of all - thank you for a great library!

---

* [ ] I added CHANGELOG entry for this change. (**I don't see a changelog file - what am I missing?**)
* [ ] Change is not relevant to the end user.

## Changes
fix prometheus interceptors not converting context errors to gRPC codes
- Previously `context.(Canceled|DeadlineExceeded)` would result in an "Unknown" grpc_code.

We use the interceptors to not only track failures but also identify when we've accidentally passed back non-grpc errors. With this fix the context errors are correctly mapped to their gRPS status counterparts. This behaves the same as what happens in the [golang server code](https://github.com/grpc/grpc-go/blob/fe72db9589696a625af72117a600ba191227b7c5/server.go#L1339-L1345). Something similar but old existed in your deprecated repo (https://github.com/grpc-ecosystem/go-grpc-prometheus/pull/84) but it was never released nor did it make it across, it would appear.

## Verification

Added unit test which triggers `context.Canceled` to verify it's no longer recorded as `grpc_code="Unknown"`
