### PR TITLE
Fix overwritten logger in zerolog example

### DIFF
--- a/interceptors/logging/examples/zerolog/example_test.go
+++ b/interceptors/logging/examples/zerolog/example_test.go
@@ -17,7 +17,7 @@ import (
 // This code is simple enough to be copied and not imported.
 func InterceptorLogger(l zerolog.Logger) logging.Logger {
 	return logging.LoggerFunc(func(ctx context.Context, lvl logging.Level, msg string, fields ...any) {
-		l = l.With().Fields(fields).Logger()
+		l := l.With().Fields(fields).Logger()
 
 		switch lvl {
 		case logging.LevelDebug:


### PR DESCRIPTION
<!--
    Keep PR title verbose enough.
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/grpc-ecosystem/go-grpc-middleware/pull/<PR-id>
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

Do not overwrite the logger variable outside closure.
Fix https://github.com/grpc-ecosystem/go-grpc-middleware/issues/572

<!-- Enumerate changes you made -->

## Verification

Follow the zerolog example in logging and see if fields in logs are not duplicated as time goes by.
