### PR TITLE
fix: Refactor logger initialization in example_test.go

### DIFF
--- a/interceptors/logging/examples/logr/example_test.go
+++ b/interceptors/logging/examples/logr/example_test.go
@@ -25,7 +25,7 @@ const (
 // This code is simple enough to be copied and not imported.
 func InterceptorLogger(l logr.Logger) logging.Logger {
 	return logging.LoggerFunc(func(_ context.Context, lvl logging.Level, msg string, fields ...any) {
-		l = l.WithValues(fields...)
+		l := l.WithValues(fields...)
 		switch lvl {
 		case logging.LevelDebug:
 			l.V(debugVerbosity).Info(msg)

--- a/interceptors/logging/examples/logrus/example_test.go
+++ b/interceptors/logging/examples/logrus/example_test.go
@@ -22,7 +22,7 @@ func InterceptorLogger(l logrus.FieldLogger) logging.Logger {
 			k, v := i.At()
 			f[k] = v
 		}
-		l = l.WithFields(f)
+		l := l.WithFields(f)
 
 		switch lvl {
 		case logging.LevelDebug:

--- a/interceptors/logging/examples/zap/example_test.go
+++ b/interceptors/logging/examples/zap/example_test.go
@@ -17,7 +17,7 @@ import (
 func InterceptorLogger(l *zap.Logger) logging.Logger {
 	return logging.LoggerFunc(func(ctx context.Context, lvl logging.Level, msg string, fields ...any) {
 		f := make([]zap.Field, 0, len(fields)/2)
-		
+
 		for i := 0; i < len(fields); i += 2 {
 			key := fields[i]
 			value := fields[i+1]
@@ -33,9 +33,8 @@ func InterceptorLogger(l *zap.Logger) logging.Logger {
 				f = append(f, zap.Any(key.(string), v))
 			}
 		}
-		
-		
-		logger = l.WithOptions(zap.AddCallerSkip(1)).With(f...)
+
+		logger := l.WithOptions(zap.AddCallerSkip(1)).With(f...)
 
 		switch lvl {
 		case logging.LevelDebug:


### PR DESCRIPTION
This commit refactors the logger initialization in the example_test.go files for the logr, logrus, and zap interceptors. In each file, the InterceptorLogger function was modified to create a new logger instance using the original logger and additional fields passed in as arguments, rather than modifying the original logger instance. This ensures that subsequent logs using the original logger are not affected by the additional fields.

The changes were made to the following files:
- interceptors/logging/examples/logr/example_test.go
- interceptors/logging/examples/logrus/example_test.go
- interceptors/logging/examples/zap/example_test.go

<!--
    Keep PR title verbose enough.
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/grpc-ecosystem/go-grpc-middleware/pull/<PR-id>
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
