### PR TITLE
Fix logrus interceptor

### DIFF
--- a/interceptors/logging/examples/logrus/example_test.go
+++ b/interceptors/logging/examples/logrus/example_test.go
@@ -18,7 +18,7 @@ func InterceptorLogger(l logrus.FieldLogger) logging.Logger {
 	return logging.LoggerFunc(func(_ context.Context, lvl logging.Level, msg string, fields ...any) {
 		f := make(map[string]any, len(fields)/2)
 		i := logging.Fields(fields).Iterator()
-		if i.Next() {
+		for i.Next() {
 			k, v := i.At()
 			f[k] = v
 		}

--- a/interceptors/logging/examples/zap/example_test.go
+++ b/interceptors/logging/examples/zap/example_test.go
@@ -17,12 +17,10 @@ import (
 func InterceptorLogger(l *zap.Logger) logging.Logger {
 	return logging.LoggerFunc(func(ctx context.Context, lvl logging.Level, msg string, fields ...any) {
 		f := make([]zap.Field, 0, len(fields)/2)
-		for i := 0; i < len(fields); i += 2 {
-			i := logging.Fields(fields).Iterator()
-			if i.Next() {
-				k, v := i.At()
-				f = append(f, zap.Any(k, v))
-			}
+		i := logging.Fields(fields).Iterator()
+		for i.Next() {
+			k, v := i.At()
+			f = append(f, zap.Any(k, v))
 		}
 		l = l.WithOptions(zap.AddCallerSkip(1)).With(f...)
 


### PR DESCRIPTION
* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

- Fixes the example logrus interceptor so that it actually includes all log fields
- Updates zap logger to use the logging fields iterator correctly, removing redundant logic. Subsumes https://github.com/grpc-ecosystem/go-grpc-middleware/pull/565

## Verification

I've tested logrus in my own project, but I haven't fully tested the zap changes, though it should be equivalent.
