### PR TITLE
fix bug : should drain channel of timer after stop

### DIFF
--- a/interceptors/retry/retry.go
+++ b/interceptors/retry/retry.go
@@ -260,7 +260,9 @@ func waitRetryBackoff(attempt uint, parentCtx context.Context, callOpts *options
 		timer := time.NewTimer(waitTime)
 		select {
 		case <-parentCtx.Done():
-			timer.Stop()
+			if !timer.Stop() {
+				<-timer.C
+			}
 			return contextErrToGrpcErr(parentCtx.Err())
 		case <-timer.C:
 		}


### PR DESCRIPTION
Ensure the channel is empty after a call to Stop.

## Changes

Drain channel.

## Verification

Document of go Timer notices that : `To ensure the channel is empty after a call to Stop, check the
// return value and drain the channel.`
