### PR TITLE
Fix linting errors

### DIFF
--- a/interceptors/protovalidate/protovalidate_test.go
+++ b/interceptors/protovalidate/protovalidate_test.go
@@ -125,6 +125,7 @@ func TestStreamServerInterceptor(t *testing.T) {
 		)
 
 		out, err := client.SendStream(context.Background(), testvalidate.BadStreamRequest)
+		assert.Nil(t, err)
 
 		_, err = out.Recv()
 		assert.Error(t, err)

--- a/providers/prometheus/server_test.go
+++ b/providers/prometheus/server_test.go
@@ -148,7 +148,8 @@ func (s *ServerInterceptorTestSuite) TestContextCancelledTreatedAsStatus() {
 	defer cancel()
 
 	stream, _ := s.Client.PingStream(ctx)
-	stream.Send(&testpb.PingStreamRequest{})
+	err := stream.Send(&testpb.PingStreamRequest{})
+	require.NoError(s.T(), err)
 	cancel()
 
 	requireValueWithRetry(s.SimpleCtx(), s.T(), 1,


### PR DESCRIPTION
## Changes

There are errors generated by `make lint`. Some of them are warned by [the other PR](https://github.com/grpc-ecosystem/go-grpc-middleware/pull/623/files) (Under the `Unchanged files with check annotations` section). 

```shell
$ make lint
...
>> verifying modules being imported
>> examining all of the Go files
>> linting all of the Go files GOGC=
server_test.go:151:13: Error return value of `stream.Send` is not checked (errcheck)
	stream.Send(&testpb.PingStreamRequest{})
	           ^
make[1]: *** [lint_module] Error 1
>> verifying modules being imported
>> examining all of the Go files
>> linting all of the Go files GOGC=
interceptors/protovalidate/protovalidate_test.go:127:8: ineffectual assignment to err (ineffassign)
		out, err := client.SendStream(context.Background(), testvalidate.BadStreamRequest)
		     ^
make[1]: *** [lint_module] Error 1
>> verifying modules being imported
>> examining all of the Go files
>> linting all of the Go files GOGC=
```

## Verification

Verified by running `make lint` again and no errors.
