### PR TITLE
feat: Support extracting fields from CallMeta

### DIFF
--- a/interceptors/logging/interceptors.go
+++ b/interceptors/logging/interceptors.go
@@ -148,9 +148,9 @@ func reportable(logger Logger, opts *options) interceptors.CommonReportableFunc 
 				fields = append(fields, "peer.address", peer.Addr.String())
 			}
 		}
-		if opts.fieldsFromCtxFn != nil {
+		if opts.fieldsFromCtxCallMetaFn != nil {
 			// fieldsFromCtxFn dups override the existing fields.
-			fields = opts.fieldsFromCtxFn(ctx).AppendUnique(fields)
+			fields = opts.fieldsFromCtxCallMetaFn(ctx, c).AppendUnique(fields)
 		}
 
 		singleUseFields := Fields{"grpc.start_time", time.Now().Format(opts.timestampFormat)}

--- a/interceptors/logging/interceptors_test.go
+++ b/interceptors/logging/interceptors_test.go
@@ -173,8 +173,7 @@ type loggingClientServerSuite struct {
 }
 
 func customFields(_ context.Context) logging.Fields {
-	// Add custom fields, one new and one that should be ignored as it duplicates the standard field.
-	return logging.Fields{"custom-field", "yolo", logging.ServiceFieldKey, "something different"}
+	return logging.Fields{"custom-field", "yolo"}
 }
 
 func TestSuite(t *testing.T) {


### PR DESCRIPTION
## Changes

Extend `logging.WithFieldsFromContext` via a new `logging.WithFieldsFromContextAndCallMeta` in a backward compatible fashion such that it supports extracting fields not only from the Context but also from the CallMeta.

## Verification

I fixed the original unit test and after the change it still passes.