### PR TITLE
Logging: Add missing variadic operator for fields

### DIFF
--- a/interceptors/logging/interceptors.go
+++ b/interceptors/logging/interceptors.go
@@ -65,7 +65,7 @@ func (c *reporter) PostMsgSend(payload any, err error, duration time.Duration) {
 				c.ctx,
 				LevelError,
 				"payload is not a google.golang.org/protobuf/proto.Message; programmatic error?",
-				fields.AppendUnique(Fields{"grpc.request.type", fmt.Sprintf("%T", payload)}),
+				fields.AppendUnique(Fields{"grpc.request.type", fmt.Sprintf("%T", payload)})...,
 			)
 			return
 		}
@@ -79,7 +79,7 @@ func (c *reporter) PostMsgSend(payload any, err error, duration time.Duration) {
 				c.ctx,
 				LevelError,
 				"payload is not a google.golang.org/protobuf/proto.Message; programmatic error?",
-				fields.AppendUnique(Fields{"grpc.response.type", fmt.Sprintf("%T", payload)}),
+				fields.AppendUnique(Fields{"grpc.response.type", fmt.Sprintf("%T", payload)})...,
 			)
 			return
 		}
@@ -110,7 +110,7 @@ func (c *reporter) PostMsgReceive(payload any, err error, duration time.Duration
 				c.ctx,
 				LevelError,
 				"payload is not a google.golang.org/protobuf/proto.Message; programmatic error?",
-				fields.AppendUnique(Fields{"grpc.request.type", fmt.Sprintf("%T", payload)}),
+				fields.AppendUnique(Fields{"grpc.request.type", fmt.Sprintf("%T", payload)})...,
 			)
 			return
 		}
@@ -124,7 +124,7 @@ func (c *reporter) PostMsgReceive(payload any, err error, duration time.Duration
 				c.ctx,
 				LevelError,
 				"payload is not a google.golang.org/protobuf/proto.Message; programmatic error?",
-				fields.AppendUnique(Fields{"grpc.response.type", fmt.Sprintf("%T", payload)}),
+				fields.AppendUnique(Fields{"grpc.response.type", fmt.Sprintf("%T", payload)})...,
 			)
 			return
 		}


### PR DESCRIPTION
## Changes

Add missing variadic operator for fields

## Verification

Manually tested with `github.com/golang/protobuf` messages. `fields` is now a slice with `2*n` elements (where `n` is the number of fields), whereas it was a slice with a single element, containing the `2*n` elements.