### PR TITLE
Support for subsystem in grpc prometheus counter and histogram metrics

### DIFF
--- a/providers/prometheus/client_test.go
+++ b/providers/prometheus/client_test.go
@@ -100,3 +100,17 @@ func (s *ClientInterceptorTestSuite) TestStreamingIncrementsMetrics() {
 	requireValue(s.T(), 1, s.clientMetrics.clientHandledCounter.WithLabelValues("server_stream", testpb.TestServiceFullName, "PingList", "FailedPrecondition"))
 	requireValueHistCount(s.T(), 2, s.clientMetrics.clientHandledHistogram.WithLabelValues("server_stream", testpb.TestServiceFullName, "PingList"))
 }
+
+func (s *ClientInterceptorTestSuite) TestWithSubsystem() {
+	counterOpts := []CounterOption{
+		WithSubsystem("subsystem1"),
+	}
+	histOpts := []HistogramOption{
+		WithHistogramSubsystem("subsystem1"),
+	}
+	clientCounterOpts := WithClientCounterOptions(counterOpts...)
+	clientMetrics := NewClientMetrics(clientCounterOpts, WithClientHandlingTimeHistogram(histOpts...))
+
+	requireSubsystemName(s.T(), "subsystem1", clientMetrics.clientStartedCounter.WithLabelValues("unary", testpb.TestServiceFullName, "dummy"))
+	requireHistSubsystemName(s.T(), "subsystem1", clientMetrics.clientHandledHistogram.WithLabelValues("unary", testpb.TestServiceFullName, "dummy"))
+}

--- a/providers/prometheus/options.go
+++ b/providers/prometheus/options.go
@@ -39,6 +39,13 @@ func WithConstLabels(labels prometheus.Labels) CounterOption {
 	}
 }
 
+// WithSubsystem allows you to add Subsytem to Counter metrics.
+func WithSubsystem(subsystem string) CounterOption {
+	return func(o *prometheus.CounterOpts) {
+		o.Subsystem = subsystem
+	}
+}
+
 // A HistogramOption lets you add options to Histogram metrics using With*
 // funcs.
 type HistogramOption func(*prometheus.HistogramOpts)
@@ -78,6 +85,13 @@ func WithHistogramOpts(opts *prometheus.HistogramOpts) HistogramOption {
 func WithHistogramConstLabels(labels prometheus.Labels) HistogramOption {
 	return func(o *prometheus.HistogramOpts) {
 		o.ConstLabels = labels
+	}
+}
+
+// WithHistogramSubsystem allows you to add Subsytem to histograms metrics.
+func WithHistogramSubsystem(subsystem string) HistogramOption {
+	return func(o *prometheus.HistogramOpts) {
+		o.Subsystem = subsystem
 	}
 }
 

--- a/providers/prometheus/options.go
+++ b/providers/prometheus/options.go
@@ -39,7 +39,7 @@ func WithConstLabels(labels prometheus.Labels) CounterOption {
 	}
 }
 
-// WithSubsystem allows you to add Subsytem to Counter metrics.
+// WithSubsystem allows you to add a Subsytem to Counter metrics.
 func WithSubsystem(subsystem string) CounterOption {
 	return func(o *prometheus.CounterOpts) {
 		o.Subsystem = subsystem
@@ -88,7 +88,7 @@ func WithHistogramConstLabels(labels prometheus.Labels) HistogramOption {
 	}
 }
 
-// WithHistogramSubsystem allows you to add Subsytem to histograms metrics.
+// WithHistogramSubsystem allows you to add a Subsytem to histograms metrics.
 func WithHistogramSubsystem(subsystem string) HistogramOption {
 	return func(o *prometheus.HistogramOpts) {
 		o.Subsystem = subsystem

--- a/providers/prometheus/server_test.go
+++ b/providers/prometheus/server_test.go
@@ -56,6 +56,20 @@ func (s *ServerInterceptorTestSuite) SetupTest() {
 	s.serverMetrics.InitializeMetrics(s.Server)
 }
 
+func (s *ServerInterceptorTestSuite) TestWithSubsystem() {
+	counterOpts := []CounterOption{
+		WithSubsystem("subsystem1"),
+	}
+	histOpts := []HistogramOption{
+		WithHistogramSubsystem("subsystem1"),
+	}
+	serverCounterOpts := WithServerCounterOptions(counterOpts...)
+	serverMetrics := NewServerMetrics(serverCounterOpts, WithServerHandlingTimeHistogram(histOpts...))
+
+	requireSubsystemName(s.T(), "subsystem1", serverMetrics.serverStartedCounter.WithLabelValues("unary", testpb.TestServiceFullName, "dummy"))
+	requireHistSubsystemName(s.T(), "subsystem1", serverMetrics.serverHandledHistogram.WithLabelValues("unary", testpb.TestServiceFullName, "dummy"))
+}
+
 func (s *ServerInterceptorTestSuite) TestRegisterPresetsStuff() {
 	registry := prometheus.NewPedanticRegistry()
 	s.Require().NoError(registry.Register(s.serverMetrics))
@@ -233,6 +247,18 @@ func toFloat64HistCount(h prometheus.Observer) uint64 {
 	panic(fmt.Errorf("collected a non-histogram metric: %s", pb))
 }
 
+func requireSubsystemName(t *testing.T, expect string, c prometheus.Collector) {
+	t.Helper()
+	metricFullName := reflect.ValueOf(*c.(prometheus.Metric).Desc()).FieldByName("fqName").String()
+
+	if strings.Split(metricFullName, "_")[0] == expect {
+		return
+	}
+
+	t.Errorf("expected %s value to start with %s; ", metricFullName, expect)
+	t.Fail()
+}
+
 func requireValue(t *testing.T, expect int, c prometheus.Collector) {
 	t.Helper()
 	v := int(testutil.ToFloat64(c))
@@ -242,6 +268,18 @@ func requireValue(t *testing.T, expect int, c prometheus.Collector) {
 
 	metricFullName := reflect.ValueOf(*c.(prometheus.Metric).Desc()).FieldByName("fqName").String()
 	t.Errorf("expected %d %s value; got %d; ", expect, metricFullName, v)
+	t.Fail()
+}
+
+func requireHistSubsystemName(t *testing.T, expect string, o prometheus.Observer) {
+	t.Helper()
+	metricFullName := reflect.ValueOf(*o.(prometheus.Metric).Desc()).FieldByName("fqName").String()
+
+	if strings.Split(metricFullName, "_")[0] == expect {
+		return
+	}
+
+	t.Errorf("expected %s value to start with %s; ", metricFullName, expect)
 	t.Fail()
 }
 


### PR DESCRIPTION
## Changes

Introduction of apis: WithSubsystem() and WithHistogramSubsystem()

## Verification

Tested locally with this new package of go-grpc-middleware
