### PR TITLE
Support for subsystem in grpc prometheus counter and histogram metrics

### DIFF
--- a/providers/prometheus/client_test.go
+++ b/providers/prometheus/client_test.go
@@ -100,3 +100,17 @@ func (s *ClientInterceptorTestSuite) TestStreamingIncrementsMetrics() {
 	requireValue(s.T(), 1, s.clientMetrics.clientHandledCounter.WithLabelValues("server_stream", testpb.TestServiceFullName, "PingList", "FailedPrecondition"))
 	requireValueHistCount(s.T(), 2, s.clientMetrics.clientHandledHistogram.WithLabelValues("server_stream", testpb.TestServiceFullName, "PingList"))
 }
+
+func (s *ClientInterceptorTestSuite) TestWithSubsystem() {
+	counterOpts := []CounterOption{
+		WithSubsystem("subsystem1"),
+	}
+	histOpts := []HistogramOption{
+		WithHistogramSubsystem("subsystem1"),
+	}
+	clientCounterOpts := WithClientCounterOptions(counterOpts...)
+	clientMetrics := NewClientMetrics(clientCounterOpts, WithClientHandlingTimeHistogram(histOpts...))
+
+	requireSubsystemName(s.T(), "subsystem1", clientMetrics.clientStartedCounter.WithLabelValues("unary", testpb.TestServiceFullName, "dummy"))
+	requireHistSubsystemName(s.T(), "subsystem1", clientMetrics.clientHandledHistogram.WithLabelValues("unary", testpb.TestServiceFullName, "dummy"))
+}

--- a/providers/prometheus/options.go
+++ b/providers/prometheus/options.go
@@ -39,6 +39,13 @@ func WithConstLabels(labels prometheus.Labels) CounterOption {
 	}
 }
 
+// WithSubsystem allows you to add a Subsystem to Counter metrics.
+func WithSubsystem(subsystem string) CounterOption {
+	return func(o *prometheus.CounterOpts) {
+		o.Subsystem = subsystem
+	}
+}
+
 // A HistogramOption lets you add options to Histogram metrics using With*
 // funcs.
 type HistogramOption func(*prometheus.HistogramOpts)
@@ -78,6 +85,13 @@ func WithHistogramOpts(opts *prometheus.HistogramOpts) HistogramOption {
 func WithHistogramConstLabels(labels prometheus.Labels) HistogramOption {
 	return func(o *prometheus.HistogramOpts) {
 		o.ConstLabels = labels
+	}
+}
+
+// WithHistogramSubsystem allows you to add a Subsystem to histograms metrics.
+func WithHistogramSubsystem(subsystem string) HistogramOption {
+	return func(o *prometheus.HistogramOpts) {
+		o.Subsystem = subsystem
 	}
 }
 

--- a/providers/prometheus/server_test.go
+++ b/providers/prometheus/server_test.go
@@ -56,6 +56,20 @@ func (s *ServerInterceptorTestSuite) SetupTest() {
 	s.serverMetrics.InitializeMetrics(s.Server)
 }
 
+func (s *ServerInterceptorTestSuite) TestWithSubsystem() {
+	counterOpts := []CounterOption{
+		WithSubsystem("subsystem1"),
+	}
+	histOpts := []HistogramOption{
+		WithHistogramSubsystem("subsystem1"),
+	}
+	serverCounterOpts := WithServerCounterOptions(counterOpts...)
+	serverMetrics := NewServerMetrics(serverCounterOpts, WithServerHandlingTimeHistogram(histOpts...))
+
+	requireSubsystemName(s.T(), "subsystem1", serverMetrics.serverStartedCounter.WithLabelValues("unary", testpb.TestServiceFullName, "dummy"))
+	requireHistSubsystemName(s.T(), "subsystem1", serverMetrics.serverHandledHistogram.WithLabelValues("unary", testpb.TestServiceFullName, "dummy"))
+}
+
 func (s *ServerInterceptorTestSuite) TestRegisterPresetsStuff() {
 	registry := prometheus.NewPedanticRegistry()
 	s.Require().NoError(registry.Register(s.serverMetrics))
@@ -233,6 +247,18 @@ func toFloat64HistCount(h prometheus.Observer) uint64 {
 	panic(fmt.Errorf("collected a non-histogram metric: %s", pb))
 }
 
+func requireSubsystemName(t *testing.T, expect string, c prometheus.Collector) {
+	t.Helper()
+	metricFullName := reflect.ValueOf(*c.(prometheus.Metric).Desc()).FieldByName("fqName").String()
+
+	if strings.Split(metricFullName, "_")[0] == expect {
+		return
+	}
+
+	t.Errorf("expected %s value to start with %s; ", metricFullName, expect)
+	t.Fail()
+}
+
 func requireValue(t *testing.T, expect int, c prometheus.Collector) {
 	t.Helper()
 	v := int(testutil.ToFloat64(c))
@@ -242,6 +268,18 @@ func requireValue(t *testing.T, expect int, c prometheus.Collector) {
 
 	metricFullName := reflect.ValueOf(*c.(prometheus.Metric).Desc()).FieldByName("fqName").String()
 	t.Errorf("expected %d %s value; got %d; ", expect, metricFullName, v)
+	t.Fail()
+}
+
+func requireHistSubsystemName(t *testing.T, expect string, o prometheus.Observer) {
+	t.Helper()
+	metricFullName := reflect.ValueOf(*o.(prometheus.Metric).Desc()).FieldByName("fqName").String()
+
+	if strings.Split(metricFullName, "_")[0] == expect {
+		return
+	}
+
+	t.Errorf("expected %s value to start with %s; ", metricFullName, expect)
 	t.Fail()
 }
 


### PR DESCRIPTION
## Changes

Introduction of apis: WithSubsystem() and WithHistogramSubsystem()


## Verification
Added new test cases for client and server metrics both.

cd /home/ubuntu/datadisk/CLONES/go-grpc-middleware-subsystem/providers/prometheus && go test -v -race ./...
=== RUN TestClientInterceptorSuite
=== RUN TestClientInterceptorSuite/TestStartedStreamingIncrementsStarted
=== RUN TestClientInterceptorSuite/TestStreamingIncrementsMetrics
=== RUN TestClientInterceptorSuite/TestUnaryIncrementsMetrics
=== RUN TestClientInterceptorSuite/TestWithSubsystem
=== NAME TestClientInterceptorSuite
interceptor_suite.go:154: stopped grpc.Server at: 127.0.0.1:40133
--- PASS: TestClientInterceptorSuite (0.24s)
--- PASS: TestClientInterceptorSuite/TestStartedStreamingIncrementsStarted (0.00s)
--- PASS: TestClientInterceptorSuite/TestStreamingIncrementsMetrics (0.01s)
--- PASS: TestClientInterceptorSuite/TestUnaryIncrementsMetrics (0.00s)
--- PASS: TestClientInterceptorSuite/TestWithSubsystem (0.00s) <<<<<<<<
=== RUN TestServerInterceptorSuite
=== RUN TestServerInterceptorSuite/TestContextCancelledTreatedAsStatus
=== RUN TestServerInterceptorSuite/TestRegisterPresetsStuff
=== RUN TestServerInterceptorSuite/TestStartedStreamingIncrementsStarted
=== RUN TestServerInterceptorSuite/TestStreamingIncrementsMetrics
=== RUN TestServerInterceptorSuite/TestUnaryIncrementsMetrics
=== RUN TestServerInterceptorSuite/TestWithSubsystem
=== NAME TestServerInterceptorSuite
interceptor_suite.go:154: stopped grpc.Server at: 127.0.0.1:38755
--- PASS: TestServerInterceptorSuite (0.73s)
--- PASS: TestServerInterceptorSuite/TestContextCancelledTreatedAsStatus (0.10s)
--- PASS: TestServerInterceptorSuite/TestRegisterPresetsStuff (0.03s)
--- PASS: TestServerInterceptorSuite/TestStartedStreamingIncrementsStarted (0.20s)
--- PASS: TestServerInterceptorSuite/TestStreamingIncrementsMetrics (0.11s)
--- PASS: TestServerInterceptorSuite/TestUnaryIncrementsMetrics (0.00s)
--- PASS: TestServerInterceptorSuite/TestWithSubsystem (0.00s) <<<<<<<<
PASS
ok github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus 1.006s
