### PR TITLE
protovalidate: add option to ignore certain message types

### DIFF
--- a/interceptors/protovalidate/example_stream_test.go
+++ b/interceptors/protovalidate/example_stream_test.go
@@ -29,7 +29,10 @@ func ExampleStreamServerInterceptor() {
 	var (
 		srv = grpc.NewServer(
 			grpc.StreamInterceptor(
-				protovalidate_middleware.StreamServerInterceptor(validator),
+				protovalidate_middleware.StreamServerInterceptor(validator,
+					protovalidate_middleware.WithIgnoreMessages(
+						(&testvalidatev1.SendStreamRequest{}).ProtoReflect().Type(),
+					)),
 			),
 		)
 		svc = &StreamService{}

--- a/interceptors/protovalidate/example_unary_test.go
+++ b/interceptors/protovalidate/example_unary_test.go
@@ -30,7 +30,11 @@ func ExampleUnaryServerInterceptor() {
 	var (
 		srv = grpc.NewServer(
 			grpc.UnaryInterceptor(
-				protovalidate_middleware.UnaryServerInterceptor(validator),
+				protovalidate_middleware.UnaryServerInterceptor(validator,
+					protovalidate_middleware.WithIgnoreMessages(
+						(&testvalidatev1.SendRequest{}).ProtoReflect().Type(),
+					),
+				),
 			),
 		)
 		svc = &UnaryService{}

--- a/interceptors/protovalidate/options.go
+++ b/interceptors/protovalidate/options.go
@@ -15,6 +15,7 @@ type options struct {
 	ignoreMessages []protoreflect.MessageType
 }
 
+// An Option lets you add options to protovalidate interceptors using With* funcs.
 type Option func(*options)
 
 func evaluateOpts(opts []Option) *options {
@@ -25,8 +26,8 @@ func evaluateOpts(opts []Option) *options {
 	return optCopy
 }
 
-// WithIgnoreMessages sets the messages that should be ignored as they are not yet ready
-// for validation at the stage this middleware operates
+// WithIgnoreMessages sets the messages that should be ignored by the validator. Use with
+// caution and ensure validation is performed elsewhere.
 func WithIgnoreMessages(msgs ...protoreflect.MessageType) Option {
 	return func(o *options) {
 		o.ignoreMessages = msgs

--- a/interceptors/protovalidate/options.go
+++ b/interceptors/protovalidate/options.go
@@ -1,0 +1,40 @@
+// Copyright (c) The go-grpc-middleware Authors.
+// Licensed under the Apache License 2.0.
+
+// Copyright 2017 David Ackroyd. All Rights Reserved.
+// See LICENSE for licensing terms.
+
+package protovalidate
+
+import (
+	"golang.org/x/exp/slices"
+	"google.golang.org/protobuf/reflect/protoreflect"
+)
+
+type options struct {
+	ignoreMessages []protoreflect.MessageType
+}
+
+type Option func(*options)
+
+func evaluateOpts(opts []Option) *options {
+	optCopy := &options{}
+	for _, o := range opts {
+		o(optCopy)
+	}
+	return optCopy
+}
+
+// WithIgnoreMessages sets the messages that should be ignored as they are not yet ready
+// for validation at the stage this middleware operates
+func WithIgnoreMessages(msgs ...protoreflect.MessageType) Option {
+	return func(o *options) {
+		o.ignoreMessages = msgs
+	}
+}
+
+func (o *options) shouldIgnoreMessage(m protoreflect.MessageType) bool {
+	return slices.ContainsFunc(o.ignoreMessages, func(t protoreflect.MessageType) bool {
+		return m == t
+	})
+}

--- a/interceptors/protovalidate/protovalidate_test.go
+++ b/interceptors/protovalidate/protovalidate_test.go
@@ -50,6 +50,20 @@ func TestUnaryServerInterceptor(t *testing.T) {
 		assert.Error(t, err)
 		assert.Equal(t, codes.InvalidArgument, status.Code(err))
 	})
+
+	interceptor = protovalidate_middleware.UnaryServerInterceptor(validator,
+		protovalidate_middleware.WithIgnoreMessages(testvalidate.BadUnaryRequest.ProtoReflect().Type()),
+	)
+
+	t.Run("invalid_email_ignored", func(t *testing.T) {
+		info := &grpc.UnaryServerInfo{
+			FullMethod: "FakeMethod",
+		}
+
+		resp, err := interceptor(context.TODO(), testvalidate.BadUnaryRequest, info, handler)
+		assert.Nil(t, err)
+		assert.Equal(t, resp, "good")
+	})
 }
 
 type server struct {


### PR DESCRIPTION
## Changes

Add an option to ignore certain types of messages that are not ready to be validated at the middleware level and require some further processing and manual `protovalidate.Validate()` call.

## Verification

Unit test to verify that bad message can be ignored because of the option implemented.
