### PR TITLE
Extend realip parsing of GRPC peer address to handle IPv6

### DIFF
--- a/interceptors/realip/realip.go
+++ b/interceptors/realip/realip.go
@@ -83,10 +83,12 @@ func getRemoteIP(ctx context.Context, trustedPeers []netip.Prefix, headers []str
 		return noIP
 	}
 
-	ip, err := netip.ParseAddr(strings.Split(pr.String(), ":")[0])
+	addrPort, err := netip.ParseAddrPort(pr.String())
 	if err != nil {
 		return noIP
 	}
+	ip := addrPort.Addr()
+
 	if len(trustedPeers) == 0 || !ipInNets(ip, trustedPeers) {
 		return ip
 	}

--- a/interceptors/realip/realip_test.go
+++ b/interceptors/realip/realip_test.go
@@ -89,8 +89,6 @@ func testUnaryServerInterceptor(t *testing.T, c testCase) {
 	interceptor := UnaryServerInterceptor(c.trustedPeers, c.headerKeys)
 	handler := func(ctx context.Context, req any) (any, error) {
 		ip, _ := FromContext(ctx)
-		fmt.Println(ip)
-		fmt.Println(c.expectedIP)
 
 		assert.Equal(t, c.expectedIP, ip)
 		return nil, nil

--- a/interceptors/realip/realip_test.go
+++ b/interceptors/realip/realip_test.go
@@ -19,23 +19,36 @@ import (
 var (
 	localnet []netip.Prefix = []netip.Prefix{
 		netip.MustParsePrefix("127.0.0.1/8"),
+		netip.MustParsePrefix("::1/128"),
 	}
 
 	privatenet []netip.Prefix = []netip.Prefix{
 		netip.MustParsePrefix("10.0.0.0/8"),
 		netip.MustParsePrefix("172.16.0.0/12"),
 		netip.MustParsePrefix("192.168.0.0/16"),
+		netip.MustParsePrefix("2002:c0a8::/32"),
 	}
 
-	privateIP netip.Addr = netip.MustParseAddr("192.168.0.1")
-	publicIP  netip.Addr = netip.MustParseAddr("8.8.8.8")
-	localhost netip.Addr = netip.MustParseAddr("127.0.0.1")
+	privateIP  netip.Addr = netip.MustParseAddr("192.168.0.1")
+	privateIP6 netip.Addr = netip.MustParseAddr("::ffff:c0a8:1")
+	publicIP   netip.Addr = netip.MustParseAddr("8.8.8.8")
+	publicIP6  netip.Addr = netip.MustParseAddr("::ffff:808:808")
+	localhost  netip.Addr = netip.MustParseAddr("127.0.0.1")
+	localhost6 netip.Addr = netip.MustParseAddr("::1")
 )
 
 func localhostPeer() *peer.Peer {
 	return &peer.Peer{
 		Addr: &net.TCPAddr{
 			IP: net.ParseIP(localhost.String()),
+		},
+	}
+}
+
+func localhost6Peer() *peer.Peer {
+	return &peer.Peer{
+		Addr: &net.TCPAddr{
+			IP: net.ParseIP(localhost6.String()),
 		},
 	}
 }
@@ -56,6 +69,14 @@ func privatePeer() *peer.Peer {
 	}
 }
 
+func private6Peer() *peer.Peer {
+	return &peer.Peer{
+		Addr: &net.TCPAddr{
+			IP: net.ParseIP(privateIP6.String()),
+		},
+	}
+}
+
 type testCase struct {
 	trustedPeers []netip.Prefix
 	headerKeys   []string
@@ -68,6 +89,8 @@ func testUnaryServerInterceptor(t *testing.T, c testCase) {
 	interceptor := UnaryServerInterceptor(c.trustedPeers, c.headerKeys)
 	handler := func(ctx context.Context, req any) (any, error) {
 		ip, _ := FromContext(ctx)
+		fmt.Println(ip)
+		fmt.Println(c.expectedIP)
 
 		assert.Equal(t, c.expectedIP, ip)
 		return nil, nil
@@ -323,6 +346,37 @@ func TestInterceptor(t *testing.T) {
 			},
 			peer:       localhostPeer(),
 			expectedIP: localhost,
+		}
+		t.Run("unary", func(t *testing.T) {
+			testUnaryServerInterceptor(t, tc)
+		})
+		t.Run("stream", func(t *testing.T) {
+			testStreamServerInterceptor(t, tc)
+		})
+	})
+	t.Run("ipv6 from grpc peer", func(t *testing.T) {
+		tc := testCase{
+			trustedPeers: localnet,
+			headerKeys:   []string{},
+			peer:         localhost6Peer(),
+			expectedIP:   localhost6,
+		}
+		t.Run("unary", func(t *testing.T) {
+			testUnaryServerInterceptor(t, tc)
+		})
+		t.Run("stream", func(t *testing.T) {
+			testStreamServerInterceptor(t, tc)
+		})
+	})
+	t.Run("ipv6 from header", func(t *testing.T) {
+		tc := testCase{
+			trustedPeers: privatenet,
+			headerKeys:   []string{XForwardedFor},
+			inputHeaders: map[string]string{
+				XForwardedFor: publicIP6.String(),
+			},
+			peer:       private6Peer(),
+			expectedIP: publicIP6,
 		}
 		t.Run("unary", func(t *testing.T) {
 			testUnaryServerInterceptor(t, tc)


### PR DESCRIPTION
## Changes

Use `netip.ParseAddrPort` instead of `strings.Split` to support extraction of both ipv4 and ipv6.

## Verification

The `interceptors/realip/realip_test.go` file was extended with additional cases.
