### PR TITLE
Fix logging Example : log only first field

### DIFF
--- a/interceptors/logging/examples/logrus/example_test.go
+++ b/interceptors/logging/examples/logrus/example_test.go
@@ -18,7 +18,7 @@ func InterceptorLogger(l logrus.FieldLogger) logging.Logger {
 	return logging.LoggerFunc(func(_ context.Context, lvl logging.Level, msg string, fields ...any) {
 		f := make(map[string]any, len(fields)/2)
 		i := logging.Fields(fields).Iterator()
-		if i.Next() {
+		for i.Next() {
 			k, v := i.At()
 			f[k] = v
 		}


### PR DESCRIPTION
<!--
    Keep PR title verbose enough.
-->

## Changes

This PR follows issue #691.
<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->

```go
grpc_logging.UnaryServerInterceptor(InterceptorLogrus(logger),grpc_logging.WithLogOnEvents(grpc_logging.FinishCall)),
```

My logging interceptor function : 
```go
func InterceptorLogrus(l log.FieldLogger) grpc_logging.Logger {
	return grpc_logging.LoggerFunc(func(_ context.Context, lvl grpc_logging.Level, msg string, fields ...any) {
		f := make(map[string]any, len(fields)/2)

		logFields := grpc_logging.Fields(fields)

		i := logFields.Iterator()

		for i.Next() {
			k, v := i.At()
			f[k] = v
		}
		l := l.WithFields(f)

		if _, ok := f["protocol"]; ok {
			l = l.WithField("system", f["protocol"])
		}
		l = l.WithField("span.kind", "server")

		switch lvl {
		case grpc_logging.LevelDebug:
			l.Debug(msg)
		case grpc_logging.LevelInfo:
			l.Info(msg)
		case grpc_logging.LevelWarn:
			l.Warn(msg)
		case grpc_logging.LevelError:
			l.Error(msg)
		default:
			l.Error(fmt.Sprintf("InterceptorLogrus : unknown level %v", lvl), " - logging message : ", msg)
		}
	})
}

```
