### PR TITLE
Extent realip interceptors with ip selection based on proxy count and list

### DIFF
--- a/interceptors/realip/examples_test.go
+++ b/interceptors/realip/examples_test.go
@@ -22,11 +22,14 @@ func ExampleUnaryServerInterceptorOpts() {
 	// Consider that there is one proxy in front,
 	// so the real client ip will be rightmost - 1 in the csv list of X-Forwarded-For
 	// Optionally you can specify TrustedProxies
-	trustedProxyCnt := uint(1)
-	opts := realip.Opts{TrustedPeers: trustedPeers, Headers: headers, TrustedProxiesCount: trustedProxyCnt}
+	opts := []realip.Option{
+		realip.WithTrustedPeers(trustedPeers),
+		realip.WithHeaders(headers),
+		realip.WithTrustedProxiesCount(1),
+	}
 	_ = grpc.NewServer(
 		grpc.ChainUnaryInterceptor(
-			realip.UnaryServerInterceptorOpts(opts),
+			realip.UnaryServerInterceptorOpts(opts...),
 		),
 	)
 }
@@ -43,11 +46,14 @@ func ExampleStreamServerInterceptorOpts() {
 	// Consider that there is one proxy in front,
 	// so the real client ip will be rightmost - 1 in the csv list of X-Forwarded-For
 	// Optionally you can specify TrustedProxies
-	trustedProxyCnt := uint(1)
-	opts := realip.Opts{TrustedPeers: trustedPeers, Headers: headers, TrustedProxiesCount: trustedProxyCnt}
+	opts := []realip.Option{
+		realip.WithTrustedPeers(trustedPeers),
+		realip.WithHeaders(headers),
+		realip.WithTrustedProxiesCount(1),
+	}
 	_ = grpc.NewServer(
 		grpc.ChainStreamInterceptor(
-			realip.StreamServerInterceptorOpts(opts),
+			realip.StreamServerInterceptorOpts(opts...),
 		),
 	)
 }

--- a/interceptors/realip/examples_test.go
+++ b/interceptors/realip/examples_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Simple example of a unary server initialization code.
-func ExampleUnaryServerInterceptor() {
+func ExampleUnaryServerInterceptorOpts() {
 	// Define list of trusted peers from which we accept forwarded-for and
 	// real-ip headers.
 	trustedPeers := []netip.Prefix{
@@ -19,15 +19,20 @@ func ExampleUnaryServerInterceptor() {
 	}
 	// Define headers to look for in the incoming request.
 	headers := []string{realip.XForwardedFor, realip.XRealIp}
+	// Consider that there is one proxy in front,
+	// so the real client ip will be rightmost - 1 in the csv list of X-Forwarded-For
+	// Optionally you can specify TrustedProxies
+	trustedProxyCnt := uint(1)
+	opts := realip.Opts{TrustedPeers: trustedPeers, Headers: headers, TrustedProxiesCount: trustedProxyCnt}
 	_ = grpc.NewServer(
 		grpc.ChainUnaryInterceptor(
-			realip.UnaryServerInterceptor(trustedPeers, headers),
+			realip.UnaryServerInterceptorOpts(opts),
 		),
 	)
 }
 
 // Simple example of a streaming server initialization code.
-func ExampleStreamServerInterceptor() {
+func ExampleStreamServerInterceptorOpts() {
 	// Define list of trusted peers from which we accept forwarded-for and
 	// real-ip headers.
 	trustedPeers := []netip.Prefix{
@@ -35,9 +40,14 @@ func ExampleStreamServerInterceptor() {
 	}
 	// Define headers to look for in the incoming request.
 	headers := []string{realip.XForwardedFor, realip.XRealIp}
+	// Consider that there is one proxy in front,
+	// so the real client ip will be rightmost - 1 in the csv list of X-Forwarded-For
+	// Optionally you can specify TrustedProxies
+	trustedProxyCnt := uint(1)
+	opts := realip.Opts{TrustedPeers: trustedPeers, Headers: headers, TrustedProxiesCount: trustedProxyCnt}
 	_ = grpc.NewServer(
 		grpc.ChainStreamInterceptor(
-			realip.StreamServerInterceptor(trustedPeers, headers),
+			realip.StreamServerInterceptorOpts(opts),
 		),
 	)
 }

--- a/interceptors/realip/options.go
+++ b/interceptors/realip/options.go
@@ -9,15 +9,12 @@ import "net/netip"
 type options struct {
 	// trustedPeers is a list of trusted peers network prefixes.
 	trustedPeers []netip.Prefix
-
 	// trustedProxies is a list of trusted proxies network prefixes.
 	// The first rightmost non-matching IP when going through X-Forwarded-For is considered the client IP.
 	trustedProxies []netip.Prefix
-
 	// trustedProxiesCount specifies the number of proxies in front that may append X-Forwarded-For.
 	// It defaults to 0.
 	trustedProxiesCount uint
-
 	// headers specifies the headers to use in real IP extraction when the request is from a trusted peer.
 	headers []string
 }

--- a/interceptors/realip/options.go
+++ b/interceptors/realip/options.go
@@ -1,0 +1,62 @@
+// Copyright (c) The go-grpc-middleware Authors.
+// Licensed under the Apache License 2.0.
+
+package realip
+
+import "net/netip"
+
+// options represents the configuration options for the realip middleware.
+type options struct {
+	// trustedPeers is a list of trusted peers network prefixes.
+	trustedPeers []netip.Prefix
+
+	// trustedProxies is a list of trusted proxies network prefixes.
+	// The first rightmost non-matching IP when going through X-Forwarded-For is considered the client IP.
+	trustedProxies []netip.Prefix
+
+	// trustedProxiesCount specifies the number of proxies in front that may append X-Forwarded-For.
+	// It defaults to 0.
+	trustedProxiesCount uint
+
+	// headers specifies the headers to use in real IP extraction when the request is from a trusted peer.
+	headers []string
+}
+
+// An Option lets you add options to realip interceptors using With* functions.
+type Option func(*options)
+
+func evaluateOpts(opts []Option) *options {
+	optCopy := &options{}
+	for _, o := range opts {
+		o(optCopy)
+	}
+	return optCopy
+}
+
+// WithTrustedPeers sets the trusted peers network prefixes.
+func WithTrustedPeers(peers []netip.Prefix) Option {
+	return func(o *options) {
+		o.trustedPeers = peers
+	}
+}
+
+// WithTrustedProxies sets the trusted proxies network prefixes.
+func WithTrustedProxies(proxies []netip.Prefix) Option {
+	return func(o *options) {
+		o.trustedProxies = proxies
+	}
+}
+
+// WithTrustedProxiesCount sets the number of trusted proxies that may append X-Forwarded-For.
+func WithTrustedProxiesCount(count uint) Option {
+	return func(o *options) {
+		o.trustedProxiesCount = count
+	}
+}
+
+// WithHeaders sets the headers to use in real IP extraction for requests from trusted peers.
+func WithHeaders(headers []string) Option {
+	return func(o *options) {
+		o.headers = headers
+	}
+}

--- a/interceptors/realip/realip.go
+++ b/interceptors/realip/realip.go
@@ -65,10 +65,32 @@ func getHeader(ctx context.Context, key string) string {
 	return md[strings.ToLower(key)][0]
 }
 
-func ipFromHeaders(ctx context.Context, headers []string) netip.Addr {
+func ipFromXForwardedFoR(trustedProxies []netip.Prefix, ips []string, idx int) netip.Addr {
+	for i := idx; i >= 0; i-- {
+		h := strings.TrimSpace(ips[i])
+		ip, err := netip.ParseAddr(h)
+		if err != nil {
+			return noIP
+		}
+		if !ipInNets(ip, trustedProxies) {
+			return ip
+		}
+	}
+	return noIP
+}
+
+func ipFromHeaders(ctx context.Context, headers []string, trustedProxies []netip.Prefix, trustedProxyCnt uint) netip.Addr {
 	for _, header := range headers {
 		a := strings.Split(getHeader(ctx, header), ",")
-		h := strings.TrimSpace(a[len(a)-1])
+		idx := len(a) - 1
+		if header == XForwardedFor {
+			idx = idx - int(trustedProxyCnt)
+			if idx < 0 {
+				continue
+			}
+			return ipFromXForwardedFoR(trustedProxies, a, idx)
+		}
+		h := strings.TrimSpace(a[idx])
 		ip, err := netip.ParseAddr(h)
 		if err == nil {
 			return ip
@@ -77,7 +99,7 @@ func ipFromHeaders(ctx context.Context, headers []string) netip.Addr {
 	return noIP
 }
 
-func getRemoteIP(ctx context.Context, trustedPeers []netip.Prefix, headers []string) netip.Addr {
+func getRemoteIP(ctx context.Context, trustedPeers, trustedProxies []netip.Prefix, headers []string, proxyCnt uint) netip.Addr {
 	pr := remotePeer(ctx)
 	if pr == nil {
 		return noIP
@@ -92,7 +114,7 @@ func getRemoteIP(ctx context.Context, trustedPeers []netip.Prefix, headers []str
 	if len(trustedPeers) == 0 || !ipInNets(ip, trustedPeers) {
 		return ip
 	}
-	if ip := ipFromHeaders(ctx, headers); ip != noIP {
+	if ip := ipFromHeaders(ctx, headers, trustedProxies, proxyCnt); ip != noIP {
 		return ip
 	}
 	// No ip from the headers, return the peer ip.
@@ -108,12 +130,42 @@ func (s *serverStream) Context() context.Context {
 	return s.ctx
 }
 
+// Opts specifies the options of the middleware
+type Opts struct {
+	// List of trusted peers network prefix. We will look at the headers from their requests
+	TrustedPeers []netip.Prefix
+	// List of trusted proxies network prefixes.
+	// When going through X-Forwarded-For the first rightmost non matching ip is the client ip.
+	TrustedProxies []netip.Prefix
+	// Number of proxies in front that may append X-Forwarded-For. 0 by default
+	TrustedProxiesCount uint
+	// Headers to use in real ip extraction when the request is from trusted peer.
+	Headers []string
+}
+
 // UnaryServerInterceptor returns a new unary server interceptor that extracts the real client IP from request headers.
 // It checks if the request comes from a trusted peer, and if so, extracts the IP from the configured headers.
 // The real IP is added to the request context.
+// See UnaryServerInterceptorOpts as it allows to configure trusted proxy ips list and count that should work better with Google LB
 func UnaryServerInterceptor(trustedPeers []netip.Prefix, headers []string) grpc.UnaryServerInterceptor {
+	return UnaryServerInterceptorOpts(Opts{TrustedPeers: trustedPeers, Headers: headers})
+}
+
+// StreamServerInterceptor returns a new stream server interceptor that extracts the real client IP from request headers.
+// It checks if the request comes from a trusted peer, and if so, extracts the IP from the configured headers.
+// The real IP is added to the request context.
+// See UnaryServerInterceptorOpts as it allows to configure trusted proxy ips list and count that should work better with Google LB
+func StreamServerInterceptor(trustedPeers []netip.Prefix, headers []string) grpc.StreamServerInterceptor {
+	return StreamServerInterceptorOpts(Opts{TrustedPeers: trustedPeers, Headers: headers})
+}
+
+// UnaryServerInterceptorOpts returns a new unary server interceptor that extracts the real client IP from request headers.
+// It checks if the request comes from a trusted peer, validates headers against trusted proxies list and trusted proxies count
+// then it extracts the IP from the configured headers.
+// The real IP is added to the request context.
+func UnaryServerInterceptorOpts(options Opts) grpc.UnaryServerInterceptor {
 	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
-		ip := getRemoteIP(ctx, trustedPeers, headers)
+		ip := getRemoteIP(ctx, options.TrustedPeers, options.TrustedProxies, options.Headers, options.TrustedProxiesCount)
 		if ip != noIP {
 			ctx = context.WithValue(ctx, realipKey{}, ip)
 		}
@@ -121,12 +173,13 @@ func UnaryServerInterceptor(trustedPeers []netip.Prefix, headers []string) grpc.
 	}
 }
 
-// StreamServerInterceptor returns a new stream server interceptor that extracts the real client IP from request headers.
-// It checks if the request comes from a trusted peer, and if so, extracts the IP from the configured headers.
+// StreamServerInterceptorOpts returns a new stream server interceptor that extracts the real client IP from request headers.
+// It checks if the request comes from a trusted peer, validates headers against trusted proxies list and trusted proxies count
+// then it extracts the IP from the configured headers.
 // The real IP is added to the request context.
-func StreamServerInterceptor(trustedPeers []netip.Prefix, headers []string) grpc.StreamServerInterceptor {
+func StreamServerInterceptorOpts(options Opts) grpc.StreamServerInterceptor {
 	return func(srv any, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
-		ip := getRemoteIP(stream.Context(), trustedPeers, headers)
+		ip := getRemoteIP(stream.Context(), options.TrustedPeers, options.TrustedProxies, options.Headers, options.TrustedProxiesCount)
 		if ip != noIP {
 			return handler(srv, &serverStream{
 				ServerStream: stream,

--- a/interceptors/realip/realip_test.go
+++ b/interceptors/realip/realip_test.go
@@ -87,17 +87,17 @@ type testCase struct {
 	expectedIP     netip.Addr
 }
 
-func (c testCase) optsFromTesCase() Opts {
-	return Opts{
-		TrustedPeers:        c.trustedPeers,
-		TrustedProxies:      c.trustedProxies,
-		TrustedProxiesCount: c.proxiesCount,
-		Headers:             c.headerKeys,
+func (c testCase) optsFromTesCase() []Option {
+	return []Option{
+		WithTrustedPeers(c.trustedPeers),
+		WithTrustedProxies(c.trustedProxies),
+		WithTrustedProxiesCount(c.proxiesCount),
+		WithHeaders(c.headerKeys),
 	}
 }
 
 func testUnaryServerInterceptor(t *testing.T, c testCase) {
-	interceptor := UnaryServerInterceptorOpts(c.optsFromTesCase())
+	interceptor := UnaryServerInterceptorOpts(c.optsFromTesCase()...)
 	handler := func(ctx context.Context, req any) (any, error) {
 		ip, _ := FromContext(ctx)
 
@@ -122,7 +122,7 @@ func testUnaryServerInterceptor(t *testing.T, c testCase) {
 }
 
 func testStreamServerInterceptor(t *testing.T, c testCase) {
-	interceptor := StreamServerInterceptorOpts(c.optsFromTesCase())
+	interceptor := StreamServerInterceptorOpts(c.optsFromTesCase()...)
 	handler := func(srv any, stream grpc.ServerStream) error {
 		ip, _ := FromContext(stream.Context())
 


### PR DESCRIPTION
The rightmost IP is not always the client IP. One example is Google:
https://cloud.google.com/load-balancing/docs/https#x-forwarded-for_header

The PR extends the IP selection for `X-Forwarded-For` based on [MDN Selecting an IP address](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For#selecting_an_ip_address).

Just so you know, it is possible to configure both at the same time. 
The user needs to be cautious when configuring these for IP selection and normally has to pick `TrustedProxies` or `TrustedProxiesCount`.

## Changes

Two new methods `UnaryServerInterceptorOpts` and `StreamServerInterceptorOpts` and options:
```go
type Opts struct {
	TrustedPeers []netip.Prefix
	TrustedProxies []netip.Prefix
	TrustedProxiesCount uint
	Headers []string
}
```

The `UnaryServerInterceptor` and `StreamServerInterceptor` are kept for backward compatibility.

## Verification

The `realip_test.go` is extended with additional test cases.
