### PR TITLE
interceptors: Update logging interceptor Reporter to re-extract fields from context before logging

### DIFF
--- a/interceptors/logging/interceptors.go
+++ b/interceptors/logging/interceptors.go
@@ -41,6 +41,10 @@ func (c *reporter) PostCall(err error, duration time.Duration) {
 	if err != nil {
 		fields = fields.AppendUnique(Fields{"grpc.error", fmt.Sprintf("%v", err)})
 	}
+	if c.opts.fieldsFromCtxCallMetaFn != nil {
+		// fieldsFromCtxFn dups override the existing fields.
+		fields = c.opts.fieldsFromCtxCallMetaFn(c.ctx, c.CallMeta).AppendUnique(fields)
+	}
 	c.logger.Log(c.ctx, c.opts.levelFunc(code), "finished call", fields.AppendUnique(c.opts.durationFieldFunc(duration))...)
 }
 
@@ -49,6 +53,10 @@ func (c *reporter) PostMsgSend(payload any, err error, duration time.Duration) {
 	fields := c.fields.WithUnique(ExtractFields(c.ctx))
 	if err != nil {
 		fields = fields.AppendUnique(Fields{"grpc.error", fmt.Sprintf("%v", err)})
+	}
+	if c.opts.fieldsFromCtxCallMetaFn != nil {
+		// fieldsFromCtxFn dups override the existing fields.
+		fields = c.opts.fieldsFromCtxCallMetaFn(c.ctx, c.CallMeta).AppendUnique(fields)
 	}
 	if !c.startCallLogged && has(c.opts.loggableEvents, StartCall) {
 		c.startCallLogged = true
@@ -96,6 +104,10 @@ func (c *reporter) PostMsgReceive(payload any, err error, duration time.Duration
 	fields := c.fields.WithUnique(ExtractFields(c.ctx))
 	if err != nil {
 		fields = fields.AppendUnique(Fields{"grpc.error", fmt.Sprintf("%v", err)})
+	}
+	if c.opts.fieldsFromCtxCallMetaFn != nil {
+		// fieldsFromCtxFn dups override the existing fields.
+		fields = c.opts.fieldsFromCtxCallMetaFn(c.ctx, c.CallMeta).AppendUnique(fields)
 	}
 	if !c.startCallLogged && has(c.opts.loggableEvents, StartCall) {
 		c.startCallLogged = true

--- a/testing/testpb/interceptor_suite.go
+++ b/testing/testpb/interceptor_suite.go
@@ -136,8 +136,33 @@ func (s *InterceptorTestSuite) ServerAddr() string {
 	return s.serverAddr
 }
 
+type ctxTestNumber struct{}
+
+var (
+	ctxTestNumberKey = &ctxTestNumber{}
+	zero             = 0
+)
+
+func ExtractCtxTestNumber(ctx context.Context) *int {
+	if v, ok := ctx.Value(ctxTestNumberKey).(*int); ok {
+		return v
+	}
+	return &zero
+}
+
+// UnaryServerInterceptor returns a new unary server interceptors that adds query information logging.
+func UnaryServerInterceptor() grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req any, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+		// newCtx := newContext(ctx, log, opts)
+		newCtx := ctx
+		resp, err := handler(newCtx, req)
+		return resp, err
+	}
+}
+
 func (s *InterceptorTestSuite) SimpleCtx() context.Context {
 	ctx, cancel := context.WithTimeout(context.TODO(), 2*time.Second)
+	ctx = context.WithValue(ctx, ctxTestNumberKey, 1)
 	s.cancels = append(s.cancels, cancel)
 	return ctx
 }

--- a/testing/testpb/pingservice.go
+++ b/testing/testpb/pingservice.go
@@ -33,7 +33,12 @@ func (s *TestPingService) PingEmpty(_ context.Context, _ *PingEmptyRequest) (*Pi
 	return &PingEmptyResponse{}, nil
 }
 
-func (s *TestPingService) Ping(_ context.Context, ping *PingRequest) (*PingResponse, error) {
+func (s *TestPingService) Ping(ctx context.Context, ping *PingRequest) (*PingResponse, error) {
+	// Modify the ctx value to verify the logger sees the value updated from the initial value
+	n := ExtractCtxTestNumber(ctx)
+	if n != nil {
+		*n = 42
+	}
 	// Send user trailers and headers.
 	return &PingResponse{Value: ping.Value, Counter: 0}, nil
 }


### PR DESCRIPTION
When using logging.WithFieldsFromContext, if the value being extracted as a log field is modified after the logging interceptor initializes the Reporter before the underlying handler is called, then the updated value will not be reflected in the log message.

To fix this, re-extract fields from the context before logging them in PostCall, PostMsgSend and PostMsgReceive, ensuring the updated values in the context are logged.


## Changes

- Call `c.opts.fieldsFromCtxCallMetaFn` `PostCall`, `PostMsgSend` and `PostMsgReceive`
- Update tests to verify log fields derived from context values are updated in the `reporter.Post*` methods

## Verification

- Unit tests
- Used this branch in a (private) project where I was expecting this behavior to work, and after the patch is applied, the expected behavior is observed.