### PR TITLE
logging: Document correct WithFieldsFromContext/WithFieldsFromContextAndCallMeta usage

### DIFF
--- a/interceptors/logging/options.go
+++ b/interceptors/logging/options.go
@@ -138,7 +138,11 @@ type (
 	fieldsFromCtxCallMetaFn func(ctx context.Context, c interceptors.CallMeta) Fields
 )
 
-// WithFieldsFromContext allows overriding existing or adding extra fields to all log messages per given context
+// WithFieldsFromContext allows overriding existing or adding extra fields to all log messages per given context.
+// If called multiple times, it overwrites the existing FieldsFromContext/WithFieldsFromContextAndCallMeta function.
+// If you need to use multiple FieldsFromContext functions then you should combine them in a wrapper fieldsFromCtxFn.
+// Only one of WithFieldsFromContextAndCallMeta or WithFieldsFromContext should
+// be used, using both will result in the last one overwriting the previous.
 func WithFieldsFromContext(f fieldsFromCtxFn) Option {
 	return func(o *options) {
 		o.fieldsFromCtxCallMetaFn = func(ctx context.Context, _ interceptors.CallMeta) Fields {
@@ -148,6 +152,10 @@ func WithFieldsFromContext(f fieldsFromCtxFn) Option {
 }
 
 // WithFieldsFromContextAndCallMeta allows overriding existing or adding extra fields to all log messages per given context and interceptor.CallMeta
+// If called multiple times, it overwrites the existing FieldsFromContext/WithFieldsFromContextAndCallMeta function.
+// If you need to use multiple WithFieldsFromContextAndCallMeta functions then you should combine them in a wrapper fieldsFromCtxCallMetaFn.
+// Only one of WithFieldsFromContextAndCallMeta or WithFieldsFromContext should
+// be used, using both will result in the last one overwriting the previous.
 func WithFieldsFromContextAndCallMeta(f fieldsFromCtxCallMetaFn) Option {
 	return func(o *options) {
 		o.fieldsFromCtxCallMetaFn = f


### PR DESCRIPTION
## Changes

Updates the doc string for `logging.WithFieldsFromContext` and `logging.WithFieldsFromContextAndCallMeta`. I mistakenly thought these accumulated, so when I tried using one helper for logging some SQL query metadata _and_ the traceID, only the traceID was getting logged since it overwrote my previous field extractor func. Without reading the source, it's not entirely obvious this is the behavior. Additionally, `WithFieldsFromContext` and `WithFieldsFromContextAndCallMeta` are mutually exclusive, so it should be documented only one should be used, and what happens when you use both, or either one of them more than once.