### PR TITLE
protovalidate: Add custom ErrorConverter 

### DIFF
--- a/interceptors/protovalidate/example_stream_test.go
+++ b/interceptors/protovalidate/example_stream_test.go
@@ -10,6 +10,8 @@ import (
 	protovalidate_middleware "github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/protovalidate"
 	testvalidatev1 "github.com/grpc-ecosystem/go-grpc-middleware/v2/testing/testvalidate/v1"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 type StreamService struct {
@@ -32,7 +34,13 @@ func ExampleStreamServerInterceptor() {
 				protovalidate_middleware.StreamServerInterceptor(validator,
 					protovalidate_middleware.WithIgnoreMessages(
 						(&testvalidatev1.SendStreamRequest{}).ProtoReflect().Type(),
-					)),
+					),
+					protovalidate_middleware.WithErrorConverter(
+						func(err error) error {
+							return status.Error(codes.InvalidArgument, err.Error())
+						},
+					),
+				),
 			),
 		)
 		svc = &StreamService{}

--- a/interceptors/protovalidate/example_unary_test.go
+++ b/interceptors/protovalidate/example_unary_test.go
@@ -11,6 +11,8 @@ import (
 	protovalidate_middleware "github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/protovalidate"
 	testvalidatev1 "github.com/grpc-ecosystem/go-grpc-middleware/v2/testing/testvalidate/v1"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 type UnaryService struct {
@@ -33,6 +35,11 @@ func ExampleUnaryServerInterceptor() {
 				protovalidate_middleware.UnaryServerInterceptor(validator,
 					protovalidate_middleware.WithIgnoreMessages(
 						(&testvalidatev1.SendRequest{}).ProtoReflect().Type(),
+					),
+					protovalidate_middleware.WithErrorConverter(
+						func(err error) error {
+							return status.Error(codes.InvalidArgument, err.Error())
+						},
 					),
 				),
 			),

--- a/interceptors/protovalidate/options.go
+++ b/interceptors/protovalidate/options.go
@@ -8,11 +8,25 @@ package protovalidate
 
 import (
 	"golang.org/x/exp/slices"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/reflect/protoreflect"
+)
+
+// DefaultErrorConverter returns InvalidArgument status with error message from validator.
+func DefaultErrorConverter(err error) error {
+	return status.Error(codes.InvalidArgument, err.Error())
+}
+
+var (
+	defaultOptions = &options{
+		errorConverter: DefaultErrorConverter,
+	}
 )
 
 type options struct {
 	ignoreMessages []protoreflect.MessageType
+	errorConverter ErrorConverter
 }
 
 // An Option lets you add options to protovalidate interceptors using With* funcs.
@@ -20,6 +34,7 @@ type Option func(*options)
 
 func evaluateOpts(opts []Option) *options {
 	optCopy := &options{}
+	*optCopy = *defaultOptions
 	for _, o := range opts {
 		o(optCopy)
 	}
@@ -38,4 +53,16 @@ func (o *options) shouldIgnoreMessage(m protoreflect.MessageType) bool {
 	return slices.ContainsFunc(o.ignoreMessages, func(t protoreflect.MessageType) bool {
 		return m == t
 	})
+}
+
+// ErrorConverter function customize the error returned by protovalidate.Validator.
+type ErrorConverter = func(err error) error
+
+// WithErrorConverter customizes the function for mapping errors.
+//
+// By default, DefaultErrorConverter used.
+func WithErrorConverter(errorConverter ErrorConverter) Option {
+	return func(o *options) {
+		o.errorConverter = errorConverter
+	}
 }

--- a/interceptors/protovalidate/protovalidate.go
+++ b/interceptors/protovalidate/protovalidate.go
@@ -5,34 +5,38 @@ package protovalidate
 
 import (
 	"context"
-	"errors"
 
 	"github.com/bufbuild/protovalidate-go"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 )
 
+func validateMessage(validator *protovalidate.Validator, o *options, req any) error {
+	msg := req.(proto.Message)
+
+	if o.shouldIgnoreMessage(msg.ProtoReflect().Type()) {
+		return nil
+	}
+
+	if err := validator.Validate(msg); err != nil {
+		return o.errorConverter(err)
+	}
+
+	return nil
+}
+
 // UnaryServerInterceptor returns a new unary server interceptor that validates incoming messages.
 func UnaryServerInterceptor(validator *protovalidate.Validator, opts ...Option) grpc.UnaryServerInterceptor {
+	o := evaluateOpts(opts)
+
 	return func(
 		ctx context.Context,
 		req interface{},
 		info *grpc.UnaryServerInfo,
 		handler grpc.UnaryHandler,
 	) (resp interface{}, err error) {
-		o := evaluateOpts(opts)
-		switch msg := req.(type) {
-		case proto.Message:
-			if o.shouldIgnoreMessage(msg.ProtoReflect().Type()) {
-				break
-			}
-			if err = validator.Validate(msg); err != nil {
-				return nil, status.Error(codes.InvalidArgument, err.Error())
-			}
-		default:
-			return nil, errors.New("unsupported message type")
+		if err := validateMessage(validator, o, req); err != nil {
+			return nil, err
 		}
 
 		return handler(ctx, req)
@@ -41,55 +45,40 @@ func UnaryServerInterceptor(validator *protovalidate.Validator, opts ...Option) 
 
 // StreamServerInterceptor returns a new streaming server interceptor that validates incoming messages.
 func StreamServerInterceptor(validator *protovalidate.Validator, opts ...Option) grpc.StreamServerInterceptor {
+	o := evaluateOpts(opts)
+
 	return func(
 		srv interface{},
 		stream grpc.ServerStream,
 		info *grpc.StreamServerInfo,
 		handler grpc.StreamHandler,
 	) error {
-		ctx := stream.Context()
-
-		wrapped := wrapServerStream(stream)
-		wrapped.wrappedContext = ctx
-		wrapped.validator = validator
-		wrapped.options = evaluateOpts(opts)
+		wrapped := wrapServerStream(stream, validator, o)
 
 		return handler(srv, wrapped)
 	}
 }
 
 func (w *wrappedServerStream) RecvMsg(m interface{}) error {
-	if err := w.ServerStream.RecvMsg(m); err != nil {
+	if err := validateMessage(w.validator, w.options, m); err != nil {
 		return err
 	}
 
-	msg := m.(proto.Message)
-	if w.options.shouldIgnoreMessage(msg.ProtoReflect().Type()) {
-		return nil
-	}
-	if err := w.validator.Validate(msg); err != nil {
-		return status.Error(codes.InvalidArgument, err.Error())
-	}
-
-	return nil
+	return w.ServerStream.RecvMsg(m)
 }
 
-// wrappedServerStream is a thin wrapper around grpc.ServerStream that allows modifying context.
+// wrappedServerStream is a thin wrapper around grpc.ServerStream that allows to validate messages.
 type wrappedServerStream struct {
 	grpc.ServerStream
-	// wrappedContext is the wrapper's own Context. You can assign it.
-	wrappedContext context.Context
-
 	validator *protovalidate.Validator
 	options   *options
 }
 
-// Context returns the wrapper's WrappedContext, overwriting the nested grpc.ServerStream.Context()
-func (w *wrappedServerStream) Context() context.Context {
-	return w.wrappedContext
-}
-
-// wrapServerStream returns a ServerStream that has the ability to overwrite context.
-func wrapServerStream(stream grpc.ServerStream) *wrappedServerStream {
-	return &wrappedServerStream{ServerStream: stream, wrappedContext: stream.Context()}
+// wrapServerStream returns a ServerStream that has the ability to validate messages.
+func wrapServerStream(
+	stream grpc.ServerStream,
+	validator *protovalidate.Validator,
+	options *options,
+) *wrappedServerStream {
+	return &wrappedServerStream{ServerStream: stream, validator: validator, options: options}
 }


### PR DESCRIPTION
## Changes

- Fix validation for grpc stream, validate before message handling.
- Add WithErrorConverter option to customize protovalidate output.

## Verification

- Add tests to related changes.
- Check in my production.
