### PR TITLE
Include error details in protovalidate responses

### DIFF
--- a/interceptors/protovalidate/protovalidate.go
+++ b/interceptors/protovalidate/protovalidate.go
@@ -29,7 +29,7 @@ func UnaryServerInterceptor(validator *protovalidate.Validator, opts ...Option) 
 				break
 			}
 			if err = validator.Validate(msg); err != nil {
-				return nil, status.Error(codes.InvalidArgument, err.Error())
+				return nil, validationErrToStatus(err).Err()
 			}
 		default:
 			return nil, errors.New("unsupported message type")
@@ -71,7 +71,7 @@ func (w *wrappedServerStream) RecvMsg(m interface{}) error {
 		return nil
 	}
 	if err := w.validator.Validate(msg); err != nil {
-		return status.Error(codes.InvalidArgument, err.Error())
+		return validationErrToStatus(err).Err()
 	}
 
 	return nil
@@ -95,4 +95,18 @@ func (w *wrappedServerStream) Context() context.Context {
 // wrapServerStream returns a ServerStream that has the ability to overwrite context.
 func wrapServerStream(stream grpc.ServerStream) *wrappedServerStream {
 	return &wrappedServerStream{ServerStream: stream, wrappedContext: stream.Context()}
+}
+
+func validationErrToStatus(err error) *status.Status {
+	// Message is invalid.
+	if valErr := new(protovalidate.ValidationError); errors.As(err, &valErr) {
+		st := status.New(codes.InvalidArgument, err.Error())
+		ds, detErr := st.WithDetails(valErr.ToProto())
+		if detErr != nil {
+			return st
+		}
+		return ds
+	}
+	// CEL expression doesn't compile or type-check.
+	return status.New(codes.Unknown, err.Error())
 }

--- a/interceptors/protovalidate/protovalidate.go
+++ b/interceptors/protovalidate/protovalidate.go
@@ -63,7 +63,10 @@ func (w *wrappedServerStream) RecvMsg(m interface{}) error {
 		return err
 	}
 
-	msg := m.(proto.Message)
+	msg, ok := m.(proto.Message)
+	if !ok {
+		return errors.New("unsupported message type")
+	}
 	if w.options.shouldIgnoreMessage(msg.ProtoReflect().Type()) {
 		return nil
 	}

--- a/interceptors/protovalidate/protovalidate_test.go
+++ b/interceptors/protovalidate/protovalidate_test.go
@@ -31,22 +31,15 @@ func TestUnaryServerInterceptor(t *testing.T) {
 	handler := func(ctx context.Context, req any) (any, error) {
 		return "good", nil
 	}
+	info := &grpc.UnaryServerInfo{FullMethod: "FakeMethod"}
 
 	t.Run("valid_email", func(t *testing.T) {
-		info := &grpc.UnaryServerInfo{
-			FullMethod: "FakeMethod",
-		}
-
 		resp, err := interceptor(context.TODO(), testvalidate.GoodUnaryRequest, info, handler)
 		assert.Nil(t, err)
 		assert.Equal(t, resp, "good")
 	})
 
 	t.Run("invalid_email", func(t *testing.T) {
-		info := &grpc.UnaryServerInfo{
-			FullMethod: "FakeMethod",
-		}
-
 		_, err = interceptor(context.TODO(), testvalidate.BadUnaryRequest, info, handler)
 		assert.Error(t, err)
 		assert.Equal(t, codes.InvalidArgument, status.Code(err))
@@ -57,10 +50,6 @@ func TestUnaryServerInterceptor(t *testing.T) {
 	)
 
 	t.Run("invalid_email_ignored", func(t *testing.T) {
-		info := &grpc.UnaryServerInfo{
-			FullMethod: "FakeMethod",
-		}
-
 		resp, err := interceptor(context.TODO(), testvalidate.BadUnaryRequest, info, handler)
 		assert.Nil(t, err)
 		assert.Equal(t, resp, "good")

--- a/interceptors/protovalidate/protovalidate_test.go
+++ b/interceptors/protovalidate/protovalidate_test.go
@@ -45,6 +45,12 @@ func TestUnaryServerInterceptor(t *testing.T) {
 		assert.Equal(t, codes.InvalidArgument, status.Code(err))
 	})
 
+	t.Run("not_protobuf", func(t *testing.T) {
+		_, err = interceptor(context.Background(), "not protobuf", info, handler)
+		assert.Error(t, err)
+		assert.Equal(t, codes.Unknown, status.Code(err))
+	})
+
 	interceptor = protovalidate_middleware.UnaryServerInterceptor(validator,
 		protovalidate_middleware.WithIgnoreMessages(testvalidate.BadUnaryRequest.ProtoReflect().Type()),
 	)


### PR DESCRIPTION
This PR improves the protovalidate middleware:

- First, it removes a potential panic from the streaming interceptor.
- Second, it uses error details to return structured information to callers
  when message validation fails. This allows clients to know which field(s) of
  the request were invalid and which validation rules failed.

Speaking as one of the protovalidate authors, we intended validation errors to
be used as gRPC error details. I didn't notice that we weren't sending them
over the wire when I first reviewed this code.

<!--
    Keep PR title verbose enough.
-->

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
