### PR TITLE
Support for namespace in grpc prometheus counter and histogram metrics

### DIFF
--- a/providers/prometheus/client_test.go
+++ b/providers/prometheus/client_test.go
@@ -114,3 +114,17 @@ func (s *ClientInterceptorTestSuite) TestWithSubsystem() {
 	requireSubsystemName(s.T(), "subsystem1", clientMetrics.clientStartedCounter.WithLabelValues("unary", testpb.TestServiceFullName, "dummy"))
 	requireHistSubsystemName(s.T(), "subsystem1", clientMetrics.clientHandledHistogram.WithLabelValues("unary", testpb.TestServiceFullName, "dummy"))
 }
+
+func (s *ClientInterceptorTestSuite) TestWithNamespace() {
+	counterOpts := []CounterOption{
+		WithNamespace("namespace1"),
+	}
+	histOpts := []HistogramOption{
+		WithHistogramNamespace("namespace1"),
+	}
+	clientCounterOpts := WithClientCounterOptions(counterOpts...)
+	clientMetrics := NewClientMetrics(clientCounterOpts, WithClientHandlingTimeHistogram(histOpts...))
+
+	requireNamespaceName(s.T(), "namespace1", clientMetrics.clientStartedCounter.WithLabelValues("unary", testpb.TestServiceFullName, "dummy"))
+	requireHistNamespaceName(s.T(), "namespace1", clientMetrics.clientHandledHistogram.WithLabelValues("unary", testpb.TestServiceFullName, "dummy"))
+}

--- a/providers/prometheus/options.go
+++ b/providers/prometheus/options.go
@@ -102,7 +102,7 @@ func WithHistogramSubsystem(subsystem string) HistogramOption {
 	}
 }
 
-// WithHistogramSubsystem allows you to add a Subsystem to histograms metrics.
+// WithHistogramNamespace allows you to add a Namespace to histograms metrics.
 func WithHistogramNamespace(namespace string) HistogramOption {
 	return func(o *prometheus.HistogramOpts) {
 		o.Namespace = namespace

--- a/providers/prometheus/options.go
+++ b/providers/prometheus/options.go
@@ -46,6 +46,13 @@ func WithSubsystem(subsystem string) CounterOption {
 	}
 }
 
+// WithNamespace allows you to add a Namespace to Counter metrics.
+func WithNamespace(namespace string) CounterOption {
+	return func(o *prometheus.CounterOpts) {
+		o.Namespace = namespace
+	}
+}
+
 // A HistogramOption lets you add options to Histogram metrics using With*
 // funcs.
 type HistogramOption func(*prometheus.HistogramOpts)
@@ -92,6 +99,13 @@ func WithHistogramConstLabels(labels prometheus.Labels) HistogramOption {
 func WithHistogramSubsystem(subsystem string) HistogramOption {
 	return func(o *prometheus.HistogramOpts) {
 		o.Subsystem = subsystem
+	}
+}
+
+// WithHistogramSubsystem allows you to add a Subsystem to histograms metrics.
+func WithHistogramNamespace(namespace string) HistogramOption {
+	return func(o *prometheus.HistogramOpts) {
+		o.Namespace = namespace
 	}
 }
 

--- a/providers/prometheus/server_test.go
+++ b/providers/prometheus/server_test.go
@@ -259,6 +259,18 @@ func requireSubsystemName(t *testing.T, expect string, c prometheus.Collector) {
 	t.Fail()
 }
 
+func requireNamespaceName(t *testing.T, expect string, c prometheus.Collector) {
+	t.Helper()
+	metricFullName := reflect.ValueOf(*c.(prometheus.Metric).Desc()).FieldByName("fqName").String()
+
+	if strings.Split(metricFullName, "_")[0] == expect {
+		return
+	}
+
+	t.Errorf("expected %s value to start with %s; ", metricFullName, expect)
+	t.Fail()
+}
+
 func requireValue(t *testing.T, expect int, c prometheus.Collector) {
 	t.Helper()
 	v := int(testutil.ToFloat64(c))
@@ -272,6 +284,18 @@ func requireValue(t *testing.T, expect int, c prometheus.Collector) {
 }
 
 func requireHistSubsystemName(t *testing.T, expect string, o prometheus.Observer) {
+	t.Helper()
+	metricFullName := reflect.ValueOf(*o.(prometheus.Metric).Desc()).FieldByName("fqName").String()
+
+	if strings.Split(metricFullName, "_")[0] == expect {
+		return
+	}
+
+	t.Errorf("expected %s value to start with %s; ", metricFullName, expect)
+	t.Fail()
+}
+
+func requireHistNamespaceName(t *testing.T, expect string, o prometheus.Observer) {
 	t.Helper()
 	metricFullName := reflect.ValueOf(*o.(prometheus.Metric).Desc()).FieldByName("fqName").String()
 


### PR DESCRIPTION
<!--
    Keep PR title verbose enough.
-->

## Changes
Introduction of apis: WithNamespace() and WithHistogramNamespace()

## Verification
Test cases are newly added in client side and server side.

```sh
$ cd providers/prometheus
$ go test -v -race ./...
=== RUN   TestClientInterceptorSuite
=== RUN   TestClientInterceptorSuite/TestStartedStreamingIncrementsStarted
=== RUN   TestClientInterceptorSuite/TestStreamingIncrementsMetrics
=== RUN   TestClientInterceptorSuite/TestUnaryIncrementsMetrics
=== RUN   TestClientInterceptorSuite/TestWithNamespace
=== RUN   TestClientInterceptorSuite/TestWithSubsystem
=== NAME  TestClientInterceptorSuite
    interceptor_suite.go:155: stopped grpc.Server at: 127.0.0.1:46203
--- PASS: TestClientInterceptorSuite (0.31s)
    --- PASS: TestClientInterceptorSuite/TestStartedStreamingIncrementsStarted (0.00s)
    --- PASS: TestClientInterceptorSuite/TestStreamingIncrementsMetrics (0.00s)
    --- PASS: TestClientInterceptorSuite/TestUnaryIncrementsMetrics (0.00s)
    --- PASS: TestClientInterceptorSuite/TestWithNamespace (0.00s)
    --- PASS: TestClientInterceptorSuite/TestWithSubsystem (0.00s)
=== RUN   TestServerInterceptorSuite
=== RUN   TestServerInterceptorSuite/TestContextCancelledTreatedAsStatus
=== RUN   TestServerInterceptorSuite/TestRegisterPresetsStuff
=== RUN   TestServerInterceptorSuite/TestStartedStreamingIncrementsStarted
=== RUN   TestServerInterceptorSuite/TestStreamingIncrementsMetrics
=== RUN   TestServerInterceptorSuite/TestUnaryIncrementsMetrics
=== RUN   TestServerInterceptorSuite/TestWithSubsystem
=== NAME  TestServerInterceptorSuite
    interceptor_suite.go:155: stopped grpc.Server at: 127.0.0.1:36147
--- PASS: TestServerInterceptorSuite (0.66s)
    --- PASS: TestServerInterceptorSuite/TestContextCancelledTreatedAsStatus (0.10s)
    --- PASS: TestServerInterceptorSuite/TestRegisterPresetsStuff (0.02s)
    --- PASS: TestServerInterceptorSuite/TestStartedStreamingIncrementsStarted (0.20s)
    --- PASS: TestServerInterceptorSuite/TestStreamingIncrementsMetrics (0.10s)
    --- PASS: TestServerInterceptorSuite/TestUnaryIncrementsMetrics (0.00s)
    --- PASS: TestServerInterceptorSuite/TestWithSubsystem (0.00s)
PASS
ok      github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus       1.982s
```
