### PR TITLE
Use ValueFromIncomingContext() to reduce allocations and copying

### DIFF
--- a/interceptors/auth/metadata.go
+++ b/interceptors/auth/metadata.go
@@ -7,12 +7,12 @@ import (
 	"context"
 	"strings"
 
-	"github.com/grpc-ecosystem/go-grpc-middleware/v2/metadata"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 )
 
-var (
+const (
 	headerAuthorize = "authorization"
 )
 
@@ -22,11 +22,11 @@ var (
 // case-insensitive format (see rfc2617, sec 1.2). If no such authorization is found, or the token
 // is of wrong scheme, an error with gRPC status `Unauthenticated` is returned.
 func AuthFromMD(ctx context.Context, expectedScheme string) (string, error) {
-	val := metadata.ExtractIncoming(ctx).Get(headerAuthorize)
-	if val == "" {
+	vals := metadata.ValueFromIncomingContext(ctx, headerAuthorize)
+	if len(vals) == 0 {
 		return "", status.Error(codes.Unauthenticated, "Request unauthenticated with "+expectedScheme)
 	}
-	scheme, token, found := strings.Cut(val, " ")
+	scheme, token, found := strings.Cut(vals[0], " ")
 	if !found {
 		return "", status.Error(codes.Unauthenticated, "Bad authorization string")
 	}

--- a/interceptors/realip/realip.go
+++ b/interceptors/realip/realip.go
@@ -53,16 +53,13 @@ func ipInNets(ip netip.Addr, nets []netip.Prefix) bool {
 }
 
 func getHeader(ctx context.Context, key string) string {
-	md, ok := metadata.FromIncomingContext(ctx)
-	if !ok {
+	vals := metadata.ValueFromIncomingContext(ctx, key)
+
+	if len(vals) == 0 {
 		return ""
 	}
 
-	if md[strings.ToLower(key)] == nil {
-		return ""
-	}
-
-	return md[strings.ToLower(key)][0]
+	return vals[0]
 }
 
 func ipFromXForwardedFoR(trustedProxies []netip.Prefix, ips []string, idx int) netip.Addr {


### PR DESCRIPTION
## Changes

This function is more memory efficient as it doesn't copy all of the metadata key-values, only what is requested.

Docs https://pkg.go.dev/google.golang.org/grpc/metadata#ValueFromIncomingContext.

## Verification

Unit tests.