### PR TITLE
prometheus: Add ip labels to server metrics

### DIFF
--- a/providers/prometheus/server_options.go
+++ b/providers/prometheus/server_options.go
@@ -9,14 +9,23 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
+func serverMetricAddIPLabel(orig []string) []string {
+	return append(orig, "grpc_server_ip", "grpc_client_ip")
+}
+
 type exemplarFromCtxFn func(ctx context.Context) prometheus.Labels
 
 type serverMetricsConfig struct {
+	// ipLabelsEnabled control whether to add grpc_server and grpc_client labels to metrics.
+	ipLabelsEnabled bool
+
 	counterOpts counterOptions
-	// serverHandledHistogram can be nil.
-	serverHandledHistogram *prometheus.HistogramVec
+
+	serverHandledHistogramEnabled bool
+	serverHandledHistogramOptions []HistogramOption
 }
 
+// ServerMetricsOption configures how we set up the server metrics.
 type ServerMetricsOption func(*serverMetricsConfig)
 
 func (c *serverMetricsConfig) apply(opts []ServerMetricsOption) {
@@ -32,17 +41,33 @@ func WithServerCounterOptions(opts ...CounterOption) ServerMetricsOption {
 	}
 }
 
+func newServerHandlingTimeHistogram(ipLabelsEnabled bool, opts []HistogramOption) *prometheus.HistogramVec {
+	labels := []string{"grpc_type", "grpc_service", "grpc_method"}
+	if ipLabelsEnabled {
+		labels = serverMetricAddIPLabel(labels)
+	}
+	return prometheus.NewHistogramVec(
+		histogramOptions(opts).apply(prometheus.HistogramOpts{
+			Name:    "grpc_server_handling_seconds",
+			Help:    "Histogram of response latency (seconds) of gRPC that had been application-level handled by the server.",
+			Buckets: prometheus.DefBuckets,
+		}),
+		labels,
+	)
+}
+
 // WithServerHandlingTimeHistogram turns on recording of handling time of RPCs.
 // Histogram metrics can be very expensive for Prometheus to retain and query.
 func WithServerHandlingTimeHistogram(opts ...HistogramOption) ServerMetricsOption {
 	return func(o *serverMetricsConfig) {
-		o.serverHandledHistogram = prometheus.NewHistogramVec(
-			histogramOptions(opts).apply(prometheus.HistogramOpts{
-				Name:    "grpc_server_handling_seconds",
-				Help:    "Histogram of response latency (seconds) of gRPC that had been application-level handled by the server.",
-				Buckets: prometheus.DefBuckets,
-			}),
-			[]string{"grpc_type", "grpc_service", "grpc_method"},
-		)
+		o.serverHandledHistogramEnabled = true
+		o.serverHandledHistogramOptions = opts
+	}
+}
+
+// WithServerIPLabelsEnabled enables adding grpc_server and grpc_client labels to metrics.
+func WithServerIPLabelsEnabled() ServerMetricsOption {
+	return func(o *serverMetricsConfig) {
+		o.ipLabelsEnabled = true
 	}
 }

--- a/providers/prometheus/server_test.go
+++ b/providers/prometheus/server_test.go
@@ -170,6 +170,236 @@ func (s *ServerInterceptorTestSuite) TestContextCancelledTreatedAsStatus() {
 		s.serverMetrics.serverHandledCounter.WithLabelValues("bidi_stream", testpb.TestServiceFullName, "PingStream", "Canceled"))
 }
 
+func TestServerInterceptorWithIPLabelsSuite(t *testing.T) {
+	s := NewServerMetrics(WithServerHandlingTimeHistogram(), WithServerIPLabelsEnabled())
+	suite.Run(t, &serverInterceptorWithIPLabelsSuite{
+		InterceptorTestSuite: &testpb.InterceptorTestSuite{
+			TestService: &testpb.TestPingService{},
+			ServerOpts: []grpc.ServerOption{
+				grpc.StreamInterceptor(s.StreamServerInterceptor()),
+				grpc.UnaryInterceptor(s.UnaryServerInterceptor()),
+			},
+		},
+		serverMetrics: s,
+		serviceName:   testpb.TestServiceFullName,
+	})
+}
+
+type serverInterceptorWithIPLabelsSuite struct {
+	*testpb.InterceptorTestSuite
+	r *require.Assertions
+
+	serverMetrics *ServerMetrics
+	serviceName   string
+}
+
+func (s *serverInterceptorWithIPLabelsSuite) SetupTest() {
+	s.r = s.Require()
+
+	s.serverMetrics.serverStartedCounter.Reset()
+	s.serverMetrics.serverHandledCounter.Reset()
+	s.serverMetrics.serverHandledHistogram.Reset()
+	s.serverMetrics.serverStreamMsgReceived.Reset()
+	s.serverMetrics.serverStreamMsgSent.Reset()
+	s.serverMetrics.InitializeMetrics(s.Server)
+}
+
+func (s *serverInterceptorWithIPLabelsSuite) grpcType(value string) string {
+	return fmt.Sprintf(`grpc_type="%s"`, value)
+}
+
+func (s *serverInterceptorWithIPLabelsSuite) grpcServiceName() string {
+	return fmt.Sprintf(`grpc_service="%s"`, s.serviceName)
+}
+
+func (s *serverInterceptorWithIPLabelsSuite) grpcMethod(value string) string {
+	return fmt.Sprintf(`grpc_method="%s"`, value)
+}
+
+func (s *serverInterceptorWithIPLabelsSuite) grpcCode(value string) string {
+	return fmt.Sprintf(`grpc_code="%s"`, value)
+}
+
+func (s *serverInterceptorWithIPLabelsSuite) grpcServerIP(value string) string {
+	return fmt.Sprintf(`grpc_server_ip="%s"`, value)
+}
+
+func (s *serverInterceptorWithIPLabelsSuite) grpcClientIP(value string) string {
+	return fmt.Sprintf(`grpc_client_ip="%s"`, value)
+}
+
+func (s *serverInterceptorWithIPLabelsSuite) TestRegisterPresetsStuff() {
+	registry := prometheus.NewPedanticRegistry()
+	s.r.NoError(registry.Register(s.serverMetrics))
+
+	allLabels := func(extras ...string) []string {
+		return append(
+			[]string{s.grpcServiceName(), s.grpcServerIP("invalid IP"), s.grpcClientIP("invalid IP")},
+			extras...,
+		)
+	}
+
+	for testID, testCase := range []struct {
+		metricName     string
+		existingLabels []string
+	}{
+		// Order of label is irrelevant.
+		{
+			"grpc_server_started_total",
+			allLabels(s.grpcMethod("PingEmpty"), s.grpcType("unary")),
+		},
+		{
+			"grpc_server_started_total",
+			allLabels(s.grpcMethod("PingList"), s.grpcType("server_stream")),
+		},
+		{
+			"grpc_server_msg_received_total",
+			allLabels(s.grpcMethod("PingList"), s.grpcType("server_stream")),
+		},
+		{
+			"grpc_server_msg_sent_total",
+			allLabels(s.grpcMethod("PingEmpty"), s.grpcType("unary")),
+		},
+		{
+			"grpc_server_handling_seconds_sum",
+			allLabels(s.grpcMethod("PingEmpty"), s.grpcType("unary")),
+		},
+		{
+			"grpc_server_handling_seconds_count",
+			allLabels(s.grpcMethod("PingList"), s.grpcType("server_stream")),
+		},
+		{
+			"grpc_server_handled_total",
+			allLabels(s.grpcMethod("PingList"), s.grpcType("server_stream"), s.grpcCode("OutOfRange")),
+		},
+		{
+			"grpc_server_handled_total",
+			allLabels(s.grpcMethod("PingList"), s.grpcType("server_stream"), s.grpcCode("Aborted")),
+		},
+		{
+			"grpc_server_handled_total",
+			allLabels(s.grpcMethod("PingEmpty"), s.grpcType("unary"), s.grpcCode("FailedPrecondition")),
+		},
+		{
+			"grpc_server_handled_total",
+			allLabels(s.grpcMethod("PingEmpty"), s.grpcType("unary"), s.grpcCode("ResourceExhausted")),
+		},
+	} {
+		lineCount := len(fetchPrometheusLines(s.T(), registry, testCase.metricName, testCase.existingLabels...))
+		s.NotZero(lineCount, "metrics must exist for test case %d", testID)
+	}
+}
+
+func (s *serverInterceptorWithIPLabelsSuite) TestUnaryIncrementsMetrics() {
+	t := s.T()
+
+	_, err := s.Client.PingEmpty(s.SimpleCtx(), &testpb.PingEmptyRequest{})
+	s.r.NoError(err)
+
+	serverIP := "127.0.0.1"
+	clientIP := "127.0.0.1"
+	requireValue(t, 1, s.serverMetrics.serverStartedCounter.WithLabelValues(
+		"unary", s.serviceName, "PingEmpty", serverIP, clientIP))
+	requireValue(t, 1, s.serverMetrics.serverHandledCounter.WithLabelValues(
+		"unary", s.serviceName, "PingEmpty", "OK", serverIP, clientIP))
+	requireValueHistCount(t, 1, s.serverMetrics.serverHandledHistogram.WithLabelValues(
+		"unary", s.serviceName, "PingEmpty", serverIP, clientIP))
+
+	_, err = s.Client.PingError(s.SimpleCtx(),
+		&testpb.PingErrorRequest{ErrorCodeReturned: uint32(codes.FailedPrecondition)})
+	s.r.Error(err)
+	requireValue(t, 1, s.serverMetrics.serverStartedCounter.WithLabelValues(
+		"unary", s.serviceName, "PingError", serverIP, clientIP))
+	requireValue(t, 1, s.serverMetrics.serverHandledCounter.WithLabelValues(
+		"unary", s.serviceName, "PingError", "FailedPrecondition", serverIP, clientIP))
+	requireValueHistCount(t, 1, s.serverMetrics.serverHandledHistogram.WithLabelValues(
+		"unary", s.serviceName, "PingError", serverIP, clientIP))
+}
+
+func (s *serverInterceptorWithIPLabelsSuite) TestStartedStreamingIncrementsStarted() {
+	t := s.T()
+
+	_, err := s.Client.PingList(s.SimpleCtx(), &testpb.PingListRequest{})
+	s.r.NoError(err)
+
+	serverIP := "127.0.0.1"
+	clientIP := "127.0.0.1"
+	requireValueWithRetry(s.SimpleCtx(), t, 1,
+		s.serverMetrics.serverStartedCounter.WithLabelValues(
+			"server_stream", testpb.TestServiceFullName, "PingList", serverIP, clientIP))
+
+	_, err = s.Client.PingList(s.SimpleCtx(), &testpb.PingListRequest{ErrorCodeReturned: uint32(codes.FailedPrecondition)})
+	s.r.NoError(err, "PingList must not fail immediately")
+	requireValueWithRetry(s.SimpleCtx(), t, 2,
+		s.serverMetrics.serverStartedCounter.WithLabelValues(
+			"server_stream", testpb.TestServiceFullName, "PingList", serverIP, clientIP))
+}
+
+func (s *serverInterceptorWithIPLabelsSuite) TestStreamingIncrementsMetrics() {
+	t := s.T()
+	ss, _ := s.Client.PingList(s.SimpleCtx(), &testpb.PingListRequest{})
+	// Do a read, just for kicks.
+	count := 0
+	for {
+		_, err := ss.Recv()
+		if err == io.EOF {
+			break
+		}
+		s.NoError(err, "reading pingList shouldn't fail")
+		count++
+	}
+	s.r.EqualValues(testpb.ListResponseCount, count, "Number of received msg on the wire must match")
+
+	serverIP := "127.0.0.1"
+	clientIP := "127.0.0.1"
+	requireValueWithRetry(s.SimpleCtx(), t, 1,
+		s.serverMetrics.serverStartedCounter.WithLabelValues(
+			"server_stream", testpb.TestServiceFullName, "PingList", serverIP, clientIP))
+	requireValueWithRetry(s.SimpleCtx(), t, 1,
+		s.serverMetrics.serverHandledCounter.WithLabelValues(
+			"server_stream", testpb.TestServiceFullName, "PingList", "OK", serverIP, clientIP))
+	requireValueWithRetry(s.SimpleCtx(), t, testpb.ListResponseCount,
+		s.serverMetrics.serverStreamMsgSent.WithLabelValues(
+			"server_stream", testpb.TestServiceFullName, "PingList", serverIP, clientIP))
+	requireValueWithRetry(s.SimpleCtx(), t, 1,
+		s.serverMetrics.serverStreamMsgReceived.WithLabelValues(
+			"server_stream", testpb.TestServiceFullName, "PingList", serverIP, clientIP))
+	requireValueWithRetryHistCount(s.SimpleCtx(), t, 1,
+		s.serverMetrics.serverHandledHistogram.WithLabelValues(
+			"server_stream", testpb.TestServiceFullName, "PingList", serverIP, clientIP))
+
+	// should return with code=FailedPrecondition
+	_, err := s.Client.PingList(s.SimpleCtx(), &testpb.PingListRequest{ErrorCodeReturned: uint32(codes.FailedPrecondition)})
+	s.r.NoError(err, "PingList must not fail immediately")
+
+	requireValueWithRetry(s.SimpleCtx(), t, 2,
+		s.serverMetrics.serverStartedCounter.WithLabelValues(
+			"server_stream", testpb.TestServiceFullName, "PingList", serverIP, clientIP))
+	requireValueWithRetry(s.SimpleCtx(), t, 1,
+		s.serverMetrics.serverHandledCounter.WithLabelValues(
+			"server_stream", testpb.TestServiceFullName, "PingList", "FailedPrecondition", serverIP, clientIP))
+	requireValueWithRetryHistCount(s.SimpleCtx(), t, 2,
+		s.serverMetrics.serverHandledHistogram.WithLabelValues(
+			"server_stream", testpb.TestServiceFullName, "PingList", serverIP, clientIP))
+}
+
+func (s *serverInterceptorWithIPLabelsSuite) TestContextCancelledTreatedAsStatus() {
+	t := s.T()
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+
+	stream, _ := s.Client.PingStream(ctx)
+	err := stream.Send(&testpb.PingStreamRequest{})
+	s.r.NoError(err)
+	cancel()
+
+	serverIP := "127.0.0.1"
+	clientIP := "127.0.0.1"
+	requireValueWithRetry(s.SimpleCtx(), t, 1,
+		s.serverMetrics.serverHandledCounter.WithLabelValues(
+			"bidi_stream", testpb.TestServiceFullName, "PingStream", "Canceled", serverIP, clientIP))
+}
+
 // fetchPrometheusLines does mocked HTTP GET request against real prometheus handler to get the same view that Prometheus
 // would have while scraping this endpoint.
 // Order of matching label vales does not matter.
@@ -194,7 +424,12 @@ func fetchPrometheusLines(t *testing.T, reg prometheus.Gatherer, metricName stri
 		}
 		matches := true
 		for _, labelValue := range matchingLabelValues {
-			if !strings.Contains(line, `"`+labelValue+`"`) {
+			// TODO: Force to use label="labelValue" format.
+			expected := labelValue
+			if !strings.Contains(labelValue, "=") {
+				expected = `"` + labelValue + `"`
+			}
+			if !strings.Contains(line, expected) {
 				matches = false
 			}
 		}


### PR DESCRIPTION
Add two labels grpc_server_ip and grpc_client_ip to the server metrics when option WithServerIPLabelsEnabled() is set. These labels are not added by default for compatibility.

This pr proposes an implementation for issue #644 

<!--
    Keep PR title verbose enough.
-->

## Changes

<!-- Enumerate changes you made -->

- Add `WithServerIPLabelsEnabled()` option for `ServerMetrics`
- Add labels **grpc_server_ip** and **grpc_client_ip** to server metrics when the option is turned on. The IPs are extracted from peer context.

## Verification

<!-- How you tested it? How do you know it works? -->

The metric scraped into Prometheus likes: 

```
grpc_server_handled_total{component="controller",grpc_client_ip="10.16.18.58",grpc_code="OK",grpc_method="StreamResourceGroup",grpc_server_ip="10.16.18.58",grpc_service="controller.Controller",grpc_type="server_stream",instance="10.16.18.58:6013",job="app-internal-metrics"}
```
