### PR TITLE
Add comment about ctxzap.AddFields not being concurrent-safe

### DIFF
--- a/logging/zap/ctxzap/context.go
+++ b/logging/zap/ctxzap/context.go
@@ -3,7 +3,7 @@ package ctxzap
 import (
 	"context"
 
-	"github.com/grpc-ecosystem/go-grpc-middleware/tags"
+	grpc_ctxtags "github.com/grpc-ecosystem/go-grpc-middleware/tags"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
@@ -21,6 +21,8 @@ var (
 )
 
 // AddFields adds zap fields to the logger.
+//
+// This function is not safe to call concurrently.
 func AddFields(ctx context.Context, fields ...zapcore.Field) {
 	l, ok := ctx.Value(ctxMarkerKey).(*ctxLogger)
 	if !ok || l == nil {


### PR DESCRIPTION
## Changes

Added comment about ctxzap.AddFields not being concurrent-safe

## Verification

This assignment is not concurrent-safe:
https://github.com/grpc-ecosystem/go-grpc-middleware/blob/43a147445b3e1feced299d1cad491fe166182145/logging/zap/ctxzap/context.go#L29

This might result in an AddTo call on an empty zapcore.Field and cause panic here:
https://github.com/uber-go/zap/blob/master/zapcore/field.go#L180

`panic: unknown field type: { 0 0  <nil>}`

Let me know if you guys want me to actually fix the issue because I think we might not want to introduce a lock here.
