### PR TITLE
logging: add WithErrorFields

### DIFF
--- a/interceptors/logging/interceptors.go
+++ b/interceptors/logging/interceptors.go
@@ -40,6 +40,9 @@ func (c *reporter) PostCall(err error, duration time.Duration) {
 	fields = fields.AppendUnique(Fields{"grpc.code", code.String()})
 	if err != nil {
 		fields = fields.AppendUnique(Fields{"grpc.error", fmt.Sprintf("%v", err)})
+		if c.opts.errorToFieldsFunc != nil {
+			fields = fields.AppendUnique(c.opts.errorToFieldsFunc(err))
+		}
 	}
 	if c.opts.fieldsFromCtxCallMetaFn != nil {
 		// fieldsFromCtxFn dups override the existing fields.
@@ -53,6 +56,9 @@ func (c *reporter) PostMsgSend(payload any, err error, duration time.Duration) {
 	fields := c.fields.WithUnique(ExtractFields(c.ctx))
 	if err != nil {
 		fields = fields.AppendUnique(Fields{"grpc.error", fmt.Sprintf("%v", err)})
+		if c.opts.errorToFieldsFunc != nil {
+			fields = fields.AppendUnique(c.opts.errorToFieldsFunc(err))
+		}
 	}
 	if c.opts.fieldsFromCtxCallMetaFn != nil {
 		// fieldsFromCtxFn dups override the existing fields.
@@ -104,6 +110,9 @@ func (c *reporter) PostMsgReceive(payload any, err error, duration time.Duration
 	fields := c.fields.WithUnique(ExtractFields(c.ctx))
 	if err != nil {
 		fields = fields.AppendUnique(Fields{"grpc.error", fmt.Sprintf("%v", err)})
+		if c.opts.errorToFieldsFunc != nil {
+			fields = fields.AppendUnique(c.opts.errorToFieldsFunc(err))
+		}
 	}
 	if c.opts.fieldsFromCtxCallMetaFn != nil {
 		// fieldsFromCtxFn dups override the existing fields.

--- a/interceptors/logging/options.go
+++ b/interceptors/logging/options.go
@@ -57,6 +57,7 @@ var (
 type options struct {
 	levelFunc               CodeToLevel
 	loggableEvents          []LoggableEvent
+	errorToFieldsFunc       ErrorToFields
 	codeFunc                ErrorToCode
 	durationFieldFunc       DurationToFields
 	timestampFormat         string
@@ -88,6 +89,9 @@ func evaluateClientOpt(opts []Option) *options {
 
 // DurationToFields function defines how to produce duration fields for logging.
 type DurationToFields func(duration time.Duration) Fields
+
+// ErrorToFields function extract fields from error.
+type ErrorToFields func(err error) Fields
 
 // ErrorToCode function determines the error code of an error.
 // This makes using custom errors with grpc middleware easier.
@@ -166,6 +170,13 @@ func WithFieldsFromContextAndCallMeta(f fieldsFromCtxCallMetaFn) Option {
 func WithLogOnEvents(events ...LoggableEvent) Option {
 	return func(o *options) {
 		o.loggableEvents = events
+	}
+}
+
+// WithErrorFields allows to extract logging fields from an error.
+func WithErrorFields(f ErrorToFields) Option {
+	return func(o *options) {
+		o.errorToFieldsFunc = f
 	}
 }
 

--- a/testing/testpb/pingservice.go
+++ b/testing/testpb/pingservice.go
@@ -45,7 +45,7 @@ func (s *TestPingService) Ping(ctx context.Context, ping *PingRequest) (*PingRes
 
 func (s *TestPingService) PingError(_ context.Context, ping *PingErrorRequest) (*PingErrorResponse, error) {
 	code := codes.Code(ping.ErrorCodeReturned)
-	return nil, status.Error(code, "Userspace error")
+	return nil, WrapFieldsInError(status.Error(code, "Userspace error"), []any{"error-field", "plop"})
 }
 
 func (s *TestPingService) PingList(ping *PingListRequest, stream TestService_PingListServer) error {


### PR DESCRIPTION
> `WithErrorFields` allows to extract logging fields from an error.

Typically to add a stack trace field or more context around the error.

## Changes

- logging: add a new `WithErrorFields` option
- testpb: add `wrappedErrFields` and helpers to inject / extract fields
- testpb: PingError return a `wrappedErrFields`

## Verification

In PingError test (logging interceptor), assertion on finished fields show `"error-field"` is present and set to the correct value.

