### PR TITLE
logging: store the propagated context in the reporter

### DIFF
--- a/interceptors/logging/interceptors.go
+++ b/interceptors/logging/interceptors.go
@@ -187,6 +187,7 @@ func reportable(logger Logger, opts *options) interceptors.CommonReportableFunc 
 		if d, ok := ctx.Deadline(); ok {
 			singleUseFields = singleUseFields.AppendUnique(Fields{"grpc.request.deadline", d.Format(opts.timestampFormat)})
 		}
+		ctx = InjectFields(ctx, fields)
 		return &reporter{
 			CallMeta:        c,
 			ctx:             ctx,
@@ -195,7 +196,7 @@ func reportable(logger Logger, opts *options) interceptors.CommonReportableFunc 
 			fields:          fields.WithUnique(singleUseFields),
 			logger:          logger,
 			kind:            kind,
-		}, InjectFields(ctx, fields)
+		}, ctx
 	}
 }
 

--- a/interceptors/logging/interceptors_test.go
+++ b/interceptors/logging/interceptors_test.go
@@ -193,7 +193,12 @@ func TestSuite(t *testing.T) {
 		&baseLoggingSuite{
 			logger: newMockLogger(),
 			InterceptorTestSuite: &testpb.InterceptorTestSuite{
-				TestService: &testpb.TestPingService{},
+				TestService: &testpb.TestPingService{
+					PingFunc: func(ctx context.Context) {
+						// Modify the fields already in the context.
+						logging.AddFields(ctx, logging.Fields{"business-field", "baguette"})
+					},
+				},
 			},
 		},
 	}
@@ -255,7 +260,8 @@ func (s *loggingClientServerSuite) TestPing() {
 		AssertFieldNotEmpty(s.T(), "grpc.start_time").
 		AssertFieldNotEmpty(s.T(), "grpc.request.deadline").
 		AssertField(s.T(), "grpc.code", "OK").
-		AssertFieldNotEmpty(s.T(), "grpc.time_ms").AssertNoMoreTags(s.T())
+		AssertFieldNotEmpty(s.T(), "grpc.time_ms").
+		AssertField(s.T(), "business-field", "baguette").AssertNoMoreTags(s.T())
 
 	clientFinishCallLogLine := lines[0]
 	assert.Equal(s.T(), logging.LevelDebug, clientFinishCallLogLine.lvl)

--- a/testing/testpb/pingservice.go
+++ b/testing/testpb/pingservice.go
@@ -27,6 +27,7 @@ var _ TestServiceServer = &TestPingService{}
 
 type TestPingService struct {
 	UnimplementedTestServiceServer
+	PingFunc func(ctx context.Context)
 }
 
 func (s *TestPingService) PingEmpty(_ context.Context, _ *PingEmptyRequest) (*PingEmptyResponse, error) {
@@ -34,6 +35,9 @@ func (s *TestPingService) PingEmpty(_ context.Context, _ *PingEmptyRequest) (*Pi
 }
 
 func (s *TestPingService) Ping(ctx context.Context, ping *PingRequest) (*PingResponse, error) {
+	if s.PingFunc != nil {
+		s.PingFunc(ctx)
+	}
 	// Modify the ctx value to verify the logger sees the value updated from the initial value
 	n := ExtractCtxTestNumber(ctx)
 	if n != nil {


### PR DESCRIPTION
https://github.com/grpc-ecosystem/go-grpc-middleware/pull/739 doesn't work without this change because the fields were not extracted from the same context than the one being propagated. I should've tested this better in my previous MR 🙌

## Changes

- Use a context with injected field in the reporter in order to support https://github.com/grpc-ecosystem/go-grpc-middleware/pull/739
- Add a helper to execute code without ciruclar dependency from the `testpb.TestPingService.Ping` method

## Verification

- Call `AddFields` with the `Ping` method using the `PingFunc` helper
- Update `TestPing` to assert a new field
