### PR TITLE
defer cancel() leaks memory

### DIFF
--- a/interceptors/retry/retry.go
+++ b/interceptors/retry/retry.go
@@ -45,7 +45,9 @@ func UnaryClientInterceptor(optFuncs ...CallOption) grpc.UnaryClientInterceptor 
 			}
 			callCtx, cancel := perCallContext(parentCtx, callOpts, attempt)
 			lastErr = invoker(callCtx, method, req, reply, cc, grpcOpts...)
-			cancel() // Clean up potential resources.
+			// Cancel the context immediately after invoking the next call in the chain to avoid
+			// holing onto its memory until this function returns.
+			cancel()
 			// TODO(mwitkow): Maybe dial and transport errors should be retriable?
 			if lastErr == nil {
 				return nil

--- a/interceptors/retry/retry.go
+++ b/interceptors/retry/retry.go
@@ -44,8 +44,8 @@ func UnaryClientInterceptor(optFuncs ...CallOption) grpc.UnaryClientInterceptor 
 				callOpts.onRetryCallback(parentCtx, attempt, lastErr)
 			}
 			callCtx, cancel := perCallContext(parentCtx, callOpts, attempt)
-			defer cancel() // Clean up potential resources.
 			lastErr = invoker(callCtx, method, req, reply, cc, grpcOpts...)
+			cancel() // Clean up potential resources.
 			// TODO(mwitkow): Maybe dial and transport errors should be retriable?
 			if lastErr == nil {
 				return nil


### PR DESCRIPTION
## Changes

Immediately call cancel() after we are done using the context. The for loop doesn't return until we succeed or parentCtx is cancelled if this takes a long time defer will never be called and this leaks memory. 

In combination with the overflow here https://github.com/grpc-ecosystem/go-grpc-middleware/pull/747 this leaks memory quite fast when the retry loops starts running every 0s because of the overflow. 

## Verification

Ran a small piece of code calling an unavailable service and pprofed it. 
