### PR TITLE
Return uint64 from exponentBase2 function

### DIFF
--- a/interceptors/retry/backoff.go
+++ b/interceptors/retry/backoff.go
@@ -27,7 +27,7 @@ func jitterUp(duration time.Duration, jitter float64) time.Duration {
 
 // exponentBase2 computes 2^(a-1) where a >= 1. If a is 0, the result is 1.
 // if a is greater than 62, the result is 2^62 to avoid overflowing int64
-func exponentBase2(a uint) uint {
+func exponentBase2(a uint) uint64 {
 	if a == 0 {
 		return 1
 	}


### PR DESCRIPTION
<!--
    Keep PR title verbose enough.
-->

## Changes
1. Change `exponentBase2` function return type to `uint64`, so it can be built with `GOARCH=386`.
<!-- Enumerate changes you made -->

## Verification
All the tests already in place passed.
<!-- How you tested it? How do you know it works? -->
