### PR TITLE
fix: correct comment typo in StreamServerInterceptor function

### DIFF
--- a/interceptors/auth/auth.go
+++ b/interceptors/auth/auth.go
@@ -49,7 +49,7 @@ func UnaryServerInterceptor(authFunc AuthFunc) grpc.UnaryServerInterceptor {
 	}
 }
 
-// StreamServerInterceptor returns a new unary server interceptors that performs per-request auth.
+// StreamServerInterceptor returns a new stream server interceptors that performs per-request auth.
 // NOTE(bwplotka): For more complex auth interceptor see https://github.com/grpc/grpc-go/blob/master/authz/grpc_authz_server_interceptors.go.
 func StreamServerInterceptor(authFunc AuthFunc) grpc.StreamServerInterceptor {
 	return func(srv any, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {


### PR DESCRIPTION
## Changes

- fix typo for StreamServerInterceptor

## Verification

run the following command
- `make all`
