### PR TITLE
Added WithIgnoreUnknownType option to protovalidate interceptor

### DIFF
--- a/interceptors/protovalidate/options.go
+++ b/interceptors/protovalidate/options.go
@@ -13,7 +13,8 @@ import (
 )
 
 type options struct {
-	ignoreMessages []protoreflect.FullName
+	ignoreMessages    []protoreflect.FullName
+	ignoreUnknownType bool
 }
 
 // An Option lets you add options to protovalidate interceptors using With* funcs.
@@ -40,6 +41,16 @@ func WithIgnoreMessages(msgs ...protoreflect.MessageType) Option {
 	slices.Sort(names)
 	return func(o *options) {
 		o.ignoreMessages = names
+	}
+}
+
+// WithIgnoreUnknownType sets the option to ignore unknown types.
+//
+// Use with caution and ensure validation is performed elsewhere.
+// This is useful for cases where your server is also a gRPC proxy.
+func WithIgnoreUnknownType() Option {
+	return func(o *options) {
+		o.ignoreUnknownType = true
 	}
 }
 

--- a/interceptors/protovalidate/protovalidate.go
+++ b/interceptors/protovalidate/protovalidate.go
@@ -68,6 +68,9 @@ func (w *wrappedServerStream) RecvMsg(m interface{}) error {
 func validateMsg(m interface{}, validator protovalidate.Validator, opts *options) error {
 	msg, ok := m.(proto.Message)
 	if !ok {
+		if opts.ignoreUnknownType {
+			return nil
+		}
 		return status.Errorf(codes.Internal, "unsupported message type: %T", m)
 	}
 	if opts.shouldIgnoreMessage(msg.ProtoReflect().Descriptor().FullName()) {


### PR DESCRIPTION
# Add WithIgnoreUnknownType option to protovalidate interceptor

## Problem

Protovalidate interceptors fail when used with transparent gRPC proxies that use custom codecs. These proxies handle raw bytes/frames instead of concrete protobuf types, causing `"unsupported message type"` errors.

## Solution

Added `WithIgnoreUnknownType()` option that allows non-protobuf messages to pass through validation while still validating actual protobuf messages.

```go
// Before: FAILS with proxy codecs
server := grpc.NewServer(
    grpc.CustomCodec(transparentCodec),
    grpc.StreamInterceptor(protovalidate.StreamServerInterceptor(validator)), // Error here
    grpc.UnknownServiceHandler(proxyHandler),
)

// After: Works with proxy codecs
server := grpc.NewServer(
    grpc.CustomCodec(transparentCodec),
    grpc.StreamInterceptor(protovalidate.StreamServerInterceptor(validator,
        protovalidate.WithIgnoreUnknownType(), // Allows compatibility
    )),
    grpc.UnknownServiceHandler(proxyHandler), // Transparent forwarding
)
```
## Changes

- Add WithIgnoreUnknownType()` in `options.go`
- Modified `validateMsg()` to skip type checking when option is enabled

## Verification
- Added tests for both unary and streaming interceptors that checks the option with and without the existing `WithIgnoreMessages` option.
