### PR TITLE
chore: enable misspell linter with golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,10 +5,15 @@ run:
   timeout: 5m
 
 linters:
+  enable:
+    - errcheck
+    - misspell
+
   settings:
     errcheck:
       exclude-functions:
         - (github.com/go-kit/log.Logger).Log
+
   exclusions:
     presets:
       - comments
@@ -20,6 +25,7 @@ formatters:
   enable:
     - gofumpt
     - goimports
+
   settings:
     gofumpt:
       extra-rules: true


### PR DESCRIPTION
## Changes

Enable to use [misspell](https://golangci-lint.run/usage/linters/#misspell) through golangci-lint