### PR TITLE
chore: enable contextcheck and fatcontext linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,8 +6,10 @@ run:
 
 linters:
   enable:
+    - contextcheck
     - errcheck
     - errorlint
+    - fatcontext
     - gocritic
     - misspell
     - testifylint


### PR DESCRIPTION
## Changes

Enable and fixes [contextcheck](https://golangci-lint.run/usage/linters/#contextcheck) and [fatcontext](https://golangci-lint.run/usage/linters/#fatcontext) linters