### PR TITLE
chore: define local-prefix from goimports

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -63,6 +63,9 @@ formatters:
   settings:
     gofumpt:
       extra-rules: true
+    goimports:
+      local-prefixes:
+        - github.com/grpc-ecosystem/go-grpc-middleware
 
 issues:
   # Maximum issues count per one linter.

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ fmt: $(GOIMPORTS)
 	@for file in $(GO_FILES_TO_FMT) ; do \
 		./goimports.sh "$${file}"; \
 	done
-	@$(GOIMPORTS) -w $(GO_FILES_TO_FMT)
+	@$(GOIMPORTS) -local github.com/grpc-ecosystem/go-grpc-middleware -w $(GO_FILES_TO_FMT)
 
 .PHONY: test
 test:

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This repository offers ready-to-use middlewares that implements gRPC interceptor
 
 Additional great feature of interceptors is the fact we can chain those. For example below you can find example server side chain of interceptors with full observabiliy correlation, auth and panic recovery:
 
-```go mdox-exec="sed -n '143,163p' examples/server/main.go"
+```go mdox-exec="sed -n '144,164p' examples/server/main.go"
 	grpcSrv := grpc.NewServer(
 		grpc.StatsHandler(otelgrpc.NewServerHandler()),
 		grpc.ChainUnaryInterceptor(

--- a/examples/client/main.go
+++ b/examples/client/main.go
@@ -11,11 +11,6 @@ import (
 	"syscall"
 	"time"
 
-	grpcprom "github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus"
-	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/logging"
-	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/timeout"
-	"github.com/grpc-ecosystem/go-grpc-middleware/v2/metadata"
-	"github.com/grpc-ecosystem/go-grpc-middleware/v2/testing/testpb"
 	"github.com/oklog/run"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -28,6 +23,12 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	grpcMetadata "google.golang.org/grpc/metadata"
+
+	grpcprom "github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus"
+	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/logging"
+	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/timeout"
+	"github.com/grpc-ecosystem/go-grpc-middleware/v2/metadata"
+	"github.com/grpc-ecosystem/go-grpc-middleware/v2/testing/testpb"
 )
 
 const (

--- a/examples/server/main.go
+++ b/examples/server/main.go
@@ -12,14 +12,6 @@ import (
 	"runtime/debug"
 	"syscall"
 
-	grpcprom "github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus"
-	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors"
-	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/auth"
-	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/logging"
-	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/recovery"
-	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/selector"
-	"github.com/grpc-ecosystem/go-grpc-middleware/v2/metadata"
-	"github.com/grpc-ecosystem/go-grpc-middleware/v2/testing/testpb"
 	"github.com/oklog/run"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -34,6 +26,15 @@ import (
 	"google.golang.org/grpc/codes"
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/status"
+
+	grpcprom "github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus"
+	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors"
+	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/auth"
+	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/logging"
+	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/recovery"
+	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/selector"
+	"github.com/grpc-ecosystem/go-grpc-middleware/v2/metadata"
+	"github.com/grpc-ecosystem/go-grpc-middleware/v2/testing/testpb"
 )
 
 const (

--- a/interceptors/auth/auth.go
+++ b/interceptors/auth/auth.go
@@ -6,8 +6,9 @@ package auth
 import (
 	"context"
 
-	middleware "github.com/grpc-ecosystem/go-grpc-middleware/v2"
 	"google.golang.org/grpc"
+
+	middleware "github.com/grpc-ecosystem/go-grpc-middleware/v2"
 )
 
 // AuthFunc is the pluggable function that performs authentication.

--- a/interceptors/auth/auth_test.go
+++ b/interceptors/auth/auth_test.go
@@ -9,9 +9,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/auth"
-	"github.com/grpc-ecosystem/go-grpc-middleware/v2/metadata"
-	"github.com/grpc-ecosystem/go-grpc-middleware/v2/testing/testpb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 	"golang.org/x/oauth2"
@@ -20,6 +17,10 @@ import (
 	"google.golang.org/grpc/credentials/oauth"
 	grpcMetadata "google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
+
+	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/auth"
+	"github.com/grpc-ecosystem/go-grpc-middleware/v2/metadata"
+	"github.com/grpc-ecosystem/go-grpc-middleware/v2/testing/testpb"
 )
 
 type authedMarker struct{}

--- a/interceptors/auth/examples_test.go
+++ b/interceptors/auth/examples_test.go
@@ -7,12 +7,13 @@ import (
 	"context"
 	"log"
 
-	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/auth"
-	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/logging"
-	"github.com/grpc-ecosystem/go-grpc-middleware/v2/testing/testpb"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/auth"
+	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/logging"
+	"github.com/grpc-ecosystem/go-grpc-middleware/v2/testing/testpb"
 )
 
 type tokenInfoKey struct{}

--- a/interceptors/auth/metadata_test.go
+++ b/interceptors/auth/metadata_test.go
@@ -7,12 +7,13 @@ import (
 	"context"
 	"testing"
 
-	"github.com/grpc-ecosystem/go-grpc-middleware/v2/metadata"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 	grpcMetadata "google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
+
+	"github.com/grpc-ecosystem/go-grpc-middleware/v2/metadata"
 )
 
 func TestAuthFromMD(t *testing.T) {

--- a/interceptors/client_test.go
+++ b/interceptors/client_test.go
@@ -12,13 +12,14 @@ import (
 	"testing"
 	"time"
 
-	"github.com/grpc-ecosystem/go-grpc-middleware/v2/testing/testpb"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/status"
+
+	"github.com/grpc-ecosystem/go-grpc-middleware/v2/testing/testpb"
 )
 
 type mockReport struct {

--- a/interceptors/logging/examples/kit/example_test.go
+++ b/interceptors/logging/examples/kit/example_test.go
@@ -9,8 +9,9 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
-	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/logging"
 	"google.golang.org/grpc"
+
+	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/logging"
 )
 
 // InterceptorLogger adapts go-kit logger to interceptor logger.

--- a/interceptors/logging/examples/log/example_test.go
+++ b/interceptors/logging/examples/log/example_test.go
@@ -9,8 +9,9 @@ import (
 	"log"
 	"os"
 
-	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/logging"
 	"google.golang.org/grpc"
+
+	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/logging"
 )
 
 // InterceptorLogger adapts standard Go logger to interceptor logger.

--- a/interceptors/logging/examples/logr/example_test.go
+++ b/interceptors/logging/examples/logr/example_test.go
@@ -8,9 +8,10 @@ import (
 	"fmt"
 
 	"github.com/go-logr/logr"
-	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/logging"
 	"google.golang.org/grpc"
 	"k8s.io/klog/v2"
+
+	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/logging"
 )
 
 // verbosity https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/logging.md#what-method-to-use

--- a/interceptors/logging/examples/logrus/example_test.go
+++ b/interceptors/logging/examples/logrus/example_test.go
@@ -7,9 +7,10 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/logging"
 	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
+
+	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/logging"
 )
 
 // InterceptorLogger adapts logrus logger to interceptor logger.

--- a/interceptors/logging/examples/skip_healthchecks/example_test.go
+++ b/interceptors/logging/examples/skip_healthchecks/example_test.go
@@ -7,10 +7,11 @@ import (
 	"context"
 	"fmt"
 
+	"google.golang.org/grpc"
+
 	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors"
 	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/logging"
 	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/selector"
-	"google.golang.org/grpc"
 )
 
 func InterceptorLogger() logging.Logger {
@@ -25,7 +26,6 @@ func SkipHealthAndReflectionRequests(_ context.Context, c interceptors.CallMeta)
 }
 
 func ExampleInterceptorLogger() {
-
 	opts := []logging.Option{
 		logging.WithLogOnEvents(logging.StartCall, logging.FinishCall),
 	}

--- a/interceptors/logging/examples/slog/example_test.go
+++ b/interceptors/logging/examples/slog/example_test.go
@@ -8,8 +8,9 @@ import (
 	"log/slog"
 	"os"
 
-	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/logging"
 	"google.golang.org/grpc"
+
+	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/logging"
 )
 
 // InterceptorLogger adapts slog logger to interceptor logger.

--- a/interceptors/logging/examples/zap/example_test.go
+++ b/interceptors/logging/examples/zap/example_test.go
@@ -7,9 +7,10 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/logging"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
+
+	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/logging"
 )
 
 // InterceptorLogger adapts zap logger to interceptor logger.

--- a/interceptors/logging/examples/zerolog/example_test.go
+++ b/interceptors/logging/examples/zerolog/example_test.go
@@ -8,9 +8,10 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/logging"
 	"github.com/rs/zerolog"
 	"google.golang.org/grpc"
+
+	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/logging"
 )
 
 // InterceptorLogger adapts zerolog logger to interceptor logger.

--- a/interceptors/logging/interceptors.go
+++ b/interceptors/logging/interceptors.go
@@ -10,10 +10,11 @@ import (
 	"io"
 	"time"
 
-	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/peer"
 	"google.golang.org/protobuf/proto"
+
+	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors"
 )
 
 type reporter struct {

--- a/interceptors/logging/interceptors_test.go
+++ b/interceptors/logging/interceptors_test.go
@@ -18,9 +18,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors"
-	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/logging"
-	"github.com/grpc-ecosystem/go-grpc-middleware/v2/testing/testpb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -28,6 +25,10 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
+
+	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors"
+	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/logging"
+	"github.com/grpc-ecosystem/go-grpc-middleware/v2/testing/testpb"
 )
 
 type testDisposableFields map[string]string

--- a/interceptors/logging/options.go
+++ b/interceptors/logging/options.go
@@ -8,9 +8,10 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors"
 )
 
 // LoggableEvent defines the events a log line can be added on.

--- a/interceptors/protovalidate/example_stream_test.go
+++ b/interceptors/protovalidate/example_stream_test.go
@@ -7,9 +7,10 @@ import (
 	"net"
 
 	"buf.build/go/protovalidate"
+	"google.golang.org/grpc"
+
 	protovalidate_middleware "github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/protovalidate"
 	testvalidatev1 "github.com/grpc-ecosystem/go-grpc-middleware/v2/testing/testvalidate/v1"
-	"google.golang.org/grpc"
 )
 
 type StreamService struct {

--- a/interceptors/protovalidate/example_unary_test.go
+++ b/interceptors/protovalidate/example_unary_test.go
@@ -8,9 +8,10 @@ import (
 	"net"
 
 	"buf.build/go/protovalidate"
+	"google.golang.org/grpc"
+
 	protovalidate_middleware "github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/protovalidate"
 	testvalidatev1 "github.com/grpc-ecosystem/go-grpc-middleware/v2/testing/testvalidate/v1"
-	"google.golang.org/grpc"
 )
 
 type UnaryService struct {

--- a/interceptors/protovalidate/protovalidate_test.go
+++ b/interceptors/protovalidate/protovalidate_test.go
@@ -11,9 +11,6 @@ import (
 
 	"buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go/buf/validate"
 	"buf.build/go/protovalidate"
-	protovalidate_middleware "github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/protovalidate"
-	"github.com/grpc-ecosystem/go-grpc-middleware/v2/testing/testvalidate"
-	testvalidatev1 "github.com/grpc-ecosystem/go-grpc-middleware/v2/testing/testvalidate/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
@@ -24,6 +21,10 @@ import (
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/types/descriptorpb"
+
+	protovalidate_middleware "github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/protovalidate"
+	"github.com/grpc-ecosystem/go-grpc-middleware/v2/testing/testvalidate"
+	testvalidatev1 "github.com/grpc-ecosystem/go-grpc-middleware/v2/testing/testvalidate/v1"
 )
 
 func TestUnaryServerInterceptor(t *testing.T) {

--- a/interceptors/ratelimit/examples_test.go
+++ b/interceptors/ratelimit/examples_test.go
@@ -6,8 +6,9 @@ package ratelimit_test
 import (
 	"context"
 
-	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/ratelimit"
 	"google.golang.org/grpc"
+
+	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/ratelimit"
 )
 
 // alwaysPassLimiter is an example limiter which implements Limiter interface.

--- a/interceptors/realip/examples_test.go
+++ b/interceptors/realip/examples_test.go
@@ -6,8 +6,9 @@ package realip_test
 import (
 	"net/netip"
 
-	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/realip"
 	"google.golang.org/grpc"
+
+	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/realip"
 )
 
 // Simple example of a unary server initialization code.

--- a/interceptors/recovery/examples_test.go
+++ b/interceptors/recovery/examples_test.go
@@ -7,10 +7,11 @@
 package recovery_test
 
 import (
-	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/recovery"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/recovery"
 )
 
 var customFunc recovery.RecoveryHandlerFunc

--- a/interceptors/recovery/interceptors_test.go
+++ b/interceptors/recovery/interceptors_test.go
@@ -10,12 +10,13 @@ import (
 	"context"
 	"testing"
 
-	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/recovery"
-	"github.com/grpc-ecosystem/go-grpc-middleware/v2/testing/testpb"
 	"github.com/stretchr/testify/suite"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/recovery"
+	"github.com/grpc-ecosystem/go-grpc-middleware/v2/testing/testpb"
 )
 
 type recoveryAssertService struct {

--- a/interceptors/retry/examples_test.go
+++ b/interceptors/retry/examples_test.go
@@ -9,9 +9,10 @@ import (
 	"io"
 	"time"
 
-	"github.com/grpc-ecosystem/go-grpc-middleware/v2/testing/testpb"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+
+	"github.com/grpc-ecosystem/go-grpc-middleware/v2/testing/testpb"
 )
 
 var cc *grpc.ClientConn

--- a/interceptors/retry/retry.go
+++ b/interceptors/retry/retry.go
@@ -11,11 +11,12 @@ import (
 	"sync"
 	"time"
 
-	"github.com/grpc-ecosystem/go-grpc-middleware/v2/metadata"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	grpcMetadata "google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
+
+	"github.com/grpc-ecosystem/go-grpc-middleware/v2/metadata"
 )
 
 const (

--- a/interceptors/retry/retry_test.go
+++ b/interceptors/retry/retry_test.go
@@ -13,7 +13,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/grpc-ecosystem/go-grpc-middleware/v2/testing/testpb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -21,6 +20,8 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
+
+	"github.com/grpc-ecosystem/go-grpc-middleware/v2/testing/testpb"
 )
 
 var (

--- a/interceptors/selector/selector.go
+++ b/interceptors/selector/selector.go
@@ -6,8 +6,9 @@ package selector
 import (
 	"context"
 
-	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors"
 	"google.golang.org/grpc"
+
+	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors"
 )
 
 // Matcher allows matching.

--- a/interceptors/selector/selector_example_test.go
+++ b/interceptors/selector/selector_example_test.go
@@ -6,14 +6,15 @@ package selector_test
 import (
 	"context"
 
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
 	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors"
 	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/auth"
 	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/logging"
 	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/ratelimit"
 	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/selector"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 // alwaysPassLimiter is an example limiter which implements Limiter interface.

--- a/interceptors/selector/selector_test.go
+++ b/interceptors/selector/selector_test.go
@@ -8,10 +8,11 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
+
+	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors"
 )
 
 // allow matches only given methods.

--- a/interceptors/server_test.go
+++ b/interceptors/server_test.go
@@ -12,12 +12,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/grpc-ecosystem/go-grpc-middleware/v2/testing/testpb"
 	"github.com/stretchr/testify/suite"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/status"
+
+	"github.com/grpc-ecosystem/go-grpc-middleware/v2/testing/testpb"
 )
 
 func TestServerInterceptorSuite(t *testing.T) {

--- a/interceptors/timeout/examples_test.go
+++ b/interceptors/timeout/examples_test.go
@@ -8,9 +8,10 @@ import (
 	"log"
 	"time"
 
+	"google.golang.org/grpc"
+
 	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/timeout"
 	"github.com/grpc-ecosystem/go-grpc-middleware/v2/testing/testpb"
-	"google.golang.org/grpc"
 )
 
 // Initialization shows an initialization sequence with a custom client request timeout.

--- a/interceptors/timeout/timeout_test.go
+++ b/interceptors/timeout/timeout_test.go
@@ -8,11 +8,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/timeout"
-	"github.com/grpc-ecosystem/go-grpc-middleware/v2/testing/testpb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
+
+	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/timeout"
+	"github.com/grpc-ecosystem/go-grpc-middleware/v2/testing/testpb"
 )
 
 type TimeoutTestServiceServer struct {

--- a/interceptors/validator/interceptors_test.go
+++ b/interceptors/validator/interceptors_test.go
@@ -9,13 +9,14 @@ import (
 	"io"
 	"testing"
 
-	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/validator"
-	"github.com/grpc-ecosystem/go-grpc-middleware/v2/testing/testpb"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/validator"
+	"github.com/grpc-ecosystem/go-grpc-middleware/v2/testing/testpb"
 )
 
 type ValidatorTestSuite struct {

--- a/interceptors/validator/validator_test.go
+++ b/interceptors/validator/validator_test.go
@@ -7,9 +7,10 @@ import (
 	"context"
 	"testing"
 
-	"github.com/grpc-ecosystem/go-grpc-middleware/v2/testing/testpb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/grpc-ecosystem/go-grpc-middleware/v2/testing/testpb"
 )
 
 func TestValidateWrapper(t *testing.T) {

--- a/metadata/metadata_test.go
+++ b/metadata/metadata_test.go
@@ -7,9 +7,10 @@ import (
 	"context"
 	"testing"
 
-	"github.com/grpc-ecosystem/go-grpc-middleware/v2/metadata"
 	"github.com/stretchr/testify/assert"
 	grpcMetadata "google.golang.org/grpc/metadata"
+
+	"github.com/grpc-ecosystem/go-grpc-middleware/v2/metadata"
 )
 
 type parentKey struct{}

--- a/providers/prometheus/client_metrics.go
+++ b/providers/prometheus/client_metrics.go
@@ -4,9 +4,10 @@
 package prometheus
 
 import (
-	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors"
 	"github.com/prometheus/client_golang/prometheus"
 	"google.golang.org/grpc"
+
+	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors"
 )
 
 // ClientMetrics represents a collection of metrics to be registered on a

--- a/providers/prometheus/client_test.go
+++ b/providers/prometheus/client_test.go
@@ -8,11 +8,12 @@ import (
 	"io"
 	"testing"
 
-	"github.com/grpc-ecosystem/go-grpc-middleware/v2/testing/testpb"
 	"github.com/stretchr/testify/suite"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	"github.com/grpc-ecosystem/go-grpc-middleware/v2/testing/testpb"
 )
 
 func TestClientInterceptorSuite(t *testing.T) {

--- a/providers/prometheus/context_labels_test.go
+++ b/providers/prometheus/context_labels_test.go
@@ -8,12 +8,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors"
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
+
+	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors"
 )
 
 func TestContextLabels(t *testing.T) {

--- a/providers/prometheus/reporter.go
+++ b/providers/prometheus/reporter.go
@@ -7,8 +7,9 @@ import (
 	"context"
 	"time"
 
-	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors"
 	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors"
 )
 
 type reporter struct {

--- a/providers/prometheus/server_metrics.go
+++ b/providers/prometheus/server_metrics.go
@@ -4,10 +4,11 @@
 package prometheus
 
 import (
-	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors"
 	"github.com/prometheus/client_golang/prometheus"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/reflection"
+
+	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors"
 )
 
 // ServerMetrics represents a collection of metrics to be registered on a

--- a/providers/prometheus/server_test.go
+++ b/providers/prometheus/server_test.go
@@ -16,7 +16,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/grpc-ecosystem/go-grpc-middleware/v2/testing/testpb"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/prometheus/client_golang/prometheus/testutil"
@@ -25,6 +24,8 @@ import (
 	"github.com/stretchr/testify/suite"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+
+	"github.com/grpc-ecosystem/go-grpc-middleware/v2/testing/testpb"
 )
 
 func TestServerInterceptorSuite(t *testing.T) {

--- a/util/backoffutils/backoff_test.go
+++ b/util/backoffutils/backoff_test.go
@@ -7,8 +7,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/grpc-ecosystem/go-grpc-middleware/v2/util/backoffutils"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/grpc-ecosystem/go-grpc-middleware/v2/util/backoffutils"
 )
 
 // scale duration by a factor


### PR DESCRIPTION
## Changes

Defines [local-prefix](https://golangci-lint.run/usage/formatters/#goimports) as `github.com/grpc-ecosystem/go-grpc-middleware` to have local imports grouped after third-party packages.