### PR TITLE
avoid unnecessary logging field creation when payload logging is disabled

### DIFF
--- a/interceptors/logging/interceptors.go
+++ b/interceptors/logging/interceptors.go
@@ -55,7 +55,7 @@ func (c *reporter) PostCall(err error, duration time.Duration) {
 func (c *reporter) PostMsgSend(payload any, err error, duration time.Duration) {
 	logStartCall := !c.startCallLogged && has(c.opts.loggableEvents, StartCall)
 	logPayloadSend := err == nil && has(c.opts.loggableEvents, PayloadSent)
-	if !(logStartCall || logPayloadSend) {
+	if !logStartCall && !logPayloadSend {
 		return
 	}
 
@@ -102,7 +102,7 @@ func (c *reporter) PostMsgSend(payload any, err error, duration time.Duration) {
 func (c *reporter) PostMsgReceive(payload any, err error, duration time.Duration) {
 	logStartCall := !c.startCallLogged && has(c.opts.loggableEvents, StartCall)
 	logPayloadReceived := err == nil && has(c.opts.loggableEvents, PayloadReceived)
-	if !(logStartCall || logPayloadReceived) {
+	if !logStartCall && !logPayloadReceived {
 		return
 	}
 


### PR DESCRIPTION
While debugging a performance-critical gRPC stream, I noticed that the logging reporter creates logging fields for every sent and received message, even when the `LoggableEvent` options `PayloadReceived` and `PayloadSent` are not set.
This unnecessary field creation increases garbage collection pressure and negatively impacts throughput.

## Changes

Added an early return in the `PostMsgSend()` and `PostMsgReceive()` to skip building logging fields when payload logging is disabled.

## Verification

Verified with existing unit tests.
