### PR TITLE
[Prometheus] Fix pre-registration of `handled` metrics with context labels

### DIFF
--- a/providers/prometheus/server_metrics.go
+++ b/providers/prometheus/server_metrics.go
@@ -130,7 +130,6 @@ func (m *ServerMetrics) preRegisterMethod(serviceName string, mInfo *grpc.Method
 
 	// Build complete label value arrays
 	startedLabels := append([]string{methodType, serviceName, methodName}, contextLabels...)
-	handledLabels := append([]string{methodType, serviceName, methodName}, contextLabels...)
 	streamLabels := append([]string{methodType, serviceName, methodName}, contextLabels...)
 
 	// These are just references (no increments), as just referencing will create the labels but not set values.
@@ -141,7 +140,7 @@ func (m *ServerMetrics) preRegisterMethod(serviceName string, mInfo *grpc.Method
 		_, _ = m.serverHandledHistogram.GetMetricWithLabelValues(streamLabels...)
 	}
 	for _, code := range interceptors.AllCodes {
-		handledLabelsWithCode := append(handledLabels, code.String())
+		handledLabelsWithCode := append([]string{methodType, serviceName, methodName, code.String()}, contextLabels...)
 		_, _ = m.serverHandledCounter.GetMetricWithLabelValues(handledLabelsWithCode...)
 	}
 }


### PR DESCRIPTION
<!--
    Keep PR title verbose enough.
-->

## Changes

Build label list `handledLabelsWithCode` in loop to place `code.String()` in correct place.
Fixes https://github.com/grpc-ecosystem/go-grpc-middleware/issues/804

## Verification

Tested with grpc server on a personal project.
